### PR TITLE
fix: #377 blockquote styles

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -101,3 +101,11 @@ h2.filter-header {
   justify-content: space-between;
   max-width: none;
 }
+
+blockquote {
+  background-color: #eaeaea;
+  border-left: .75rem solid #999;
+  padding: .1rem 1rem 1rem 1rem;
+  margin-top: 1rem;
+  max-width: 40rem;
+}


### PR DESCRIPTION
# Summary

Adding in blockquote styles to fix #377

I just made up some basic styles, but if there is an example I can update it to whats currently in use.

### Screenshots

Before:
![image](https://github.com/open5e/open5e/assets/480259/894f2d1d-66d9-4f55-81ef-484e7e6978bc)

After:
<img width="687" alt="Screenshot 2023-05-15 at 10 42 35 PM" src="https://github.com/open5e/open5e/assets/480259/64fc5923-bbd8-4df0-ad25-d3e0f32cc4ff">
<img width="697" alt="Screenshot 2023-05-15 at 10 42 30 PM" src="https://github.com/open5e/open5e/assets/480259/49043df8-6e42-49f6-87a4-f874897513e0">

### Tech Notes

Styling elements directly obviously isn't the best approach, but it seemed the most straightforward, for now. This will effect all blockquotes on the site, which is what I think we'd want? 
