### PR TITLE
Accessibility improvements for the monster list, spell list and magic item list pages

### DIFF
--- a/assets/_variables.scss
+++ b/assets/_variables.scss
@@ -25,5 +25,6 @@ $color-mana: #166c9c;
 $color-fog: #f4f4f4;
 $color-smoke: #d4d4d4;
 $color-granite: #888;
+$color-gray: #767676;
 $color-basalt: #333;
 $color-darkness: #111;

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -42,6 +42,14 @@ html {
 
 .fiterable-table {
   width: 100%;
+
+  tbody {
+    th {
+      font-weight: normal;
+      border: none;
+      vertical-align: top;
+    }
+  }
 }
 
 .fade-enter-active,
@@ -71,4 +79,16 @@ html {
       margin-left: 0;
     }
   }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -40,8 +40,12 @@ html {
   margin: 0;
 }
 
-.fiterable-table {
+.filterable-table {
   width: 100%;
+
+  thead th {
+    vertical-align: baseline;
+  }
 
   tbody {
     th {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -81,6 +81,28 @@ html {
   }
 }
 
+.filter-header-wrapper {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+
+  row-gap: 0.75rem;
+  border-bottom: 3px solid #e74c3c;
+  padding-bottom: 0.25rem;
+
+  .filter-header {
+    border: none;
+    padding-bottom: 0;
+    margin-top: 0;
+  }
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+    padding-bottom: 0.75rem;
+  }
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/components/FilterInput.vue
+++ b/components/FilterInput.vue
@@ -1,24 +1,35 @@
 <template>
   <div class="filter-wrapper">
+    <label
+      :for="id"
+      class="floating-label"
+      :class="{ 'floating-label--top': isLabelFloating }"
+      >{{ placeholder }}</label
+    >
     <input
+      :id="id"
+      ref="input"
       v-model="filterText"
       class="filter-input"
       type="input"
-      :placeholder="placeholder"
+      aria-description="Results will update as you type."
       @input.stop="onInput"
+      @focus="onFocus"
+      @blur="onBlur"
     />
-    <img
-      v-show="filterValue"
-      class="filter-clear"
-      src="/img/x-close.png"
-      @click="clearSearch()"
-    />
+    <button v-show="filterValue" class="filter-clear" @click="clearSearch()">
+      <img src="/img/x-close.png" alt="Clear filter" />
+    </button>
   </div>
 </template>
 
 <script>
 export default {
   props: {
+    id: {
+      type: String,
+      required: true,
+    },
     placeholder: {
       type: String,
       default: 'Filter...',
@@ -27,6 +38,7 @@ export default {
   data() {
     return {
       filterText: '',
+      isLabelFloating: false,
     };
   },
   computed: {
@@ -37,9 +49,20 @@ export default {
   methods: {
     clearSearch: function () {
       this.filterText = '';
+      this.isLabelFloating = false;
+      this.$emit('input', this.filterText);
+      this.$refs.input.focus();
     },
     onInput: function () {
       this.$emit('input', this.filterText);
+    },
+    onFocus: function () {
+      this.isLabelFloating = true;
+    },
+    onBlur: function () {
+      if (this.filterText.length === 0) {
+        this.isLabelFloating = false;
+      }
     },
   },
 };
@@ -68,6 +91,28 @@ export default {
     pointer-events: none;
   }
 
+  .floating-label {
+    position: absolute;
+    top: 6px;
+    left: 28px;
+    padding-inline: 4px;
+
+    font-size: 1rem;
+    font-weight: normal;
+    font-family: 'Source Sans Pro', sans-serif;
+    color: gray;
+    pointer-events: none;
+    transition: all 100ms ease;
+
+    &.floating-label--top {
+      top: -10px;
+      left: auto;
+      right: 32px;
+
+      background: #fff;
+    }
+  }
+
   .filter-input {
     font-size: $font-size-base;
     border-radius: 2px;
@@ -86,15 +131,23 @@ export default {
   }
 
   .filter-clear {
-    opacity: 0.3;
+    background: none;
+    border: none;
     position: absolute;
     top: 0.6rem;
     right: 0.6rem;
+    padding: 0;
     width: 1rem;
-    cursor: pointer;
+    height: 1rem;
 
-    &:hover {
-      opacity: 0.6;
+    img {
+      opacity: 0.3;
+      width: 100%;
+      cursor: pointer;
+
+      &:hover {
+        opacity: 0.6;
+      }
     }
   }
 }

--- a/components/FilterInput.vue
+++ b/components/FilterInput.vue
@@ -100,7 +100,7 @@ export default {
     font-size: 1rem;
     font-weight: normal;
     font-family: 'Source Sans Pro', sans-serif;
-    color: gray;
+    color: $color-gray;
     pointer-events: none;
     transition: all 100ms ease;
 

--- a/components/SortableTableHeader.vue
+++ b/components/SortableTableHeader.vue
@@ -1,0 +1,63 @@
+<template>
+  <th :aria-sort="currentSortDir" class="sortable-table-header">
+    <button @click="onClick">
+      <span class="label">
+        <slot></slot>
+      </span>
+      <span
+        aria-hidden="true"
+        class="arrow"
+        :class="{ 'arrow--visible': currentSortDir }"
+        >{{ isAscending ? '▲' : '▼' }}</span
+      >
+    </button>
+  </th>
+</template>
+
+<script>
+export default {
+  props: {
+    currentSortDir: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    isAscending() {
+      return this.currentSortDir === 'ascending';
+    },
+  },
+  methods: {
+    onClick() {
+      console.log('new', this.isAscending ? 'descending' : 'ascending');
+      this.$emit('sort', this.isAscending ? 'descending' : 'ascending');
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.sortable-table-header {
+  button {
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+
+    font-weight: bold;
+
+    .label {
+      text-decoration: underline;
+    }
+
+    .arrow {
+      margin-left: 2px;
+      visibility: hidden;
+
+      &.arrow--visible {
+        visibility: visible;
+      }
+    }
+  }
+}
+</style>

--- a/components/SourceTag.vue
+++ b/components/SourceTag.vue
@@ -17,7 +17,7 @@ export default {
       default: '#ffffff',
     },
     background: {
-      default: '#707070',
+      default: '#767676',
     },
     border: {
       default: '1px solid #999999',
@@ -33,10 +33,10 @@ export default {
   padding: 1px 3px;
   line-height: 10px;
   border-radius: 4px;
-  margin-left: 3px;
+  margin-left: 5px;
   margin-right: 3px;
   text-transform: uppercase;
   position: relative;
-  top: -3px;
+  top: -1px;
 }
 </style>

--- a/components/SourceTag.vue
+++ b/components/SourceTag.vue
@@ -17,7 +17,7 @@ export default {
       default: '#ffffff',
     },
     background: {
-      default: '#aaaaaa',
+      default: '#707070',
     },
     border: {
       default: '1px solid #999999',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,9 +2,7 @@
   <div>
     <div class="app-wrapper" :class="{ 'show-sidebar': showSidebar }">
       <div class="sidebar">
-        <nuxt-link to="/">
-          <h1>Open5e</h1>
-        </nuxt-link>
+        <nuxt-link to="/" class="logo"> Open5e </nuxt-link>
         <input
           v-model="searchText"
           class="input-search"
@@ -240,9 +238,7 @@
       <div class="content-wrapper">
         <div class="mobile-header">
           <div class="sidebar-toggle" @click="toggleSidebar" />
-          <nuxt-link to="/">
-            <h1>Open5e</h1>
-          </nuxt-link>
+          <nuxt-link to="/" class="logo"> Open5e </nuxt-link>
           <div class="spacer" />
         </div>
         <ol class="breadcrumb">
@@ -473,7 +469,7 @@ footer {
     }
   }
 
-  h1 {
+  .logo {
     display: inline-block;
     margin: 0;
     padding: 0;
@@ -512,12 +508,15 @@ footer {
     display: block;
   }
 
-  h1 {
+  .logo {
     display: block;
     background-color: $color-fireball;
     padding: 1rem 3rem 1rem 1rem;
     cursor: pointer;
     margin-top: 0;
+    font-family: Lora, serif;
+    font-weight: 600;
+    font-size: 2em;
   }
 
   ul {

--- a/pages/magicitems/magicitem-list.vue
+++ b/pages/magicitems/magicitem-list.vue
@@ -21,15 +21,9 @@
       <div v-else aria-live="assertive" aria-atomic="true">
         <p v-if="!itemListLength">No results</p>
       </div>
-      <div
-        v-for="(letter, key) in itemsByLetter"
-        :key="letter[0].name.charAt(0)"
-      >
-        <h3 v-if="!filter">
-          {{ key.toUpperCase() }}
-        </h3>
+      <div v-if="filter">
         <ul class="list--items">
-          <li v-for="item in letter" :key="item.name">
+          <li v-for="item in filteredItems" :key="item.name">
             <nuxt-link
               tag="a"
               :params="{ id: item.slug }"
@@ -45,6 +39,33 @@
             />
           </li>
         </ul>
+      </div>
+      <div v-else>
+        <div
+          v-for="(letter, key) in itemsByLetter"
+          :key="letter[0].name.charAt(0)"
+        >
+          <h4>
+            {{ key.toUpperCase() }}
+          </h4>
+          <ul class="list--items">
+            <li v-for="item in letter" :key="item.name">
+              <nuxt-link
+                tag="a"
+                :params="{ id: item.slug }"
+                :to="`/magicitems/${item.slug}`"
+              >
+                {{ item.name }}
+              </nuxt-link>
+              <source-tag
+                v-if="item.document__slug && item.document__slug !== 'wotc-srd'"
+                class=""
+                :title="item.document__title"
+                :text="item.document__slug"
+              />
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </section>

--- a/pages/magicitems/magicitem-list.vue
+++ b/pages/magicitems/magicitem-list.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container">
     <div class="filter-header-wrapper">
-      <h2 class="filter-header">Magic Item List</h2>
+      <h1 class="filter-header">Magic Item List</h1>
       <filter-input
         id="filter-items"
         ref="filter"
@@ -11,11 +11,11 @@
         @keyup.enter="onFilterEnter"
       />
     </div>
-    <h3 ref="results" class="sr-only" tabindex="-1" @keyup.esc="focusFilter">
+    <h2 ref="results" class="sr-only" tabindex="-1" @keyup.esc="focusFilter">
       {{ itemListLength }}
       {{ itemListLength === 1 ? 'Result' : 'Results' }}
       <span v-if="filter.length > 0">&nbsp;for {{ filter }}</span>
-    </h3>
+    </h2>
     <div :class="{ 'three-column': !filter }">
       <p v-if="!items.length">Loading...</p>
       <div v-else aria-live="assertive" aria-atomic="true">
@@ -44,10 +44,11 @@
         <div
           v-for="(letter, key) in itemsByLetter"
           :key="letter[0].name.charAt(0)"
+          class="letter-list"
         >
-          <h4>
+          <h3>
             {{ key.toUpperCase() }}
-          </h4>
+          </h3>
           <ul class="list--items">
             <li v-for="item in letter" :key="item.name">
               <nuxt-link
@@ -139,4 +140,12 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style scoped lang="scss">
+.letter-list {
+  break-inside: avoid-column;
+
+  &:first-child h3 {
+    margin-top: 0;
+  }
+}
+</style>

--- a/pages/magicitems/magicitem-list.vue
+++ b/pages/magicitems/magicitem-list.vue
@@ -1,36 +1,51 @@
 <template>
   <section class="container">
-    <h2 class="filter-header">
-      <span>Magic Item List</span>
-      <filter-input placeholder="Filter items..." @input="updateFilter" />
-    </h2>
+    <div class="filter-header-wrapper">
+      <h2 class="filter-header">Magic Item List</h2>
+      <filter-input
+        id="filter-items"
+        ref="filter"
+        class="filter"
+        placeholder="Filter items..."
+        @input="updateFilter"
+        @keyup.enter="onFilterEnter"
+      />
+    </div>
+    <h3 ref="results" class="sr-only" tabindex="-1" @keyup.esc="focusFilter">
+      {{ itemListLength }}
+      {{ itemListLength === 1 ? 'Result' : 'Results' }}
+      <span v-if="filter.length > 0">&nbsp;for {{ filter }}</span>
+    </h3>
     <div :class="{ 'three-column': !filter }">
       <p v-if="!items.length">Loading...</p>
-      <p v-else-if="!itemListLength">No results</p>
-      <ul
+      <div v-else aria-live="assertive" aria-atomic="true">
+        <p v-if="!itemListLength">No results</p>
+      </div>
+      <div
         v-for="(letter, key) in itemsByLetter"
         :key="letter[0].name.charAt(0)"
-        class="list--items"
       >
         <h3 v-if="!filter">
           {{ key.toUpperCase() }}
         </h3>
-        <li v-for="item in letter" :key="item.name">
-          <nuxt-link
-            tag="a"
-            :params="{ id: item.slug }"
-            :to="`/magicitems/${item.slug}`"
-          >
-            {{ item.name }}
-          </nuxt-link>
-          <source-tag
-            v-if="item.document__slug && item.document__slug !== 'wotc-srd'"
-            class=""
-            :title="item.document__title"
-            :text="item.document__slug"
-          />
-        </li>
-      </ul>
+        <ul class="list--items">
+          <li v-for="item in letter" :key="item.name">
+            <nuxt-link
+              tag="a"
+              :params="{ id: item.slug }"
+              :to="`/magicitems/${item.slug}`"
+            >
+              {{ item.name }}
+            </nuxt-link>
+            <source-tag
+              v-if="item.document__slug && item.document__slug !== 'wotc-srd'"
+              class=""
+              :title="item.document__title"
+              :text="item.document__slug"
+            />
+          </li>
+        </ul>
+      </div>
     </div>
   </section>
 </template>
@@ -56,21 +71,23 @@ export default {
   },
   computed: {
     items: function () {
-      return this.store.allMagicItems;
+      return [...this.store.allMagicItems].sort((a, b) =>
+        a.slug.localeCompare(b.slug)
+      );
     },
     // a computed getter
     itemsByLetter: function () {
       let letters = {};
-      for (let i = 0; i < this.filteredSpells.length; i++) {
-        let firstLetter = this.filteredSpells[i].name.charAt(0).toLowerCase();
+      for (let i = 0; i < this.filteredItems.length; i++) {
+        let firstLetter = this.filteredItems[i].name.charAt(0).toLowerCase();
         if (!(firstLetter in letters)) {
           letters[firstLetter] = [];
         }
-        letters[firstLetter].push(this.filteredSpells[i]);
+        letters[firstLetter].push(this.filteredItems[i]);
       }
       return letters;
     },
-    filteredSpells: function () {
+    filteredItems: function () {
       return this.items.filter((item) => {
         return item.name.toLowerCase().indexOf(this.filter.toLowerCase()) > -1;
       });
@@ -90,6 +107,12 @@ export default {
   methods: {
     updateFilter: function (val) {
       this.filter = val;
+    },
+    onFilterEnter: function () {
+      this.$refs.results.focus();
+    },
+    focusFilter: function () {
+      this.$refs.filter.$refs.input.focus();
     },
   },
 };

--- a/pages/monsters/monster-list.vue
+++ b/pages/monsters/monster-list.vue
@@ -30,30 +30,37 @@
         </div>
       </div>
       <p v-if="!monstersList.length">Loading...</p>
-      <table v-else class="fiterable-table">
+      <table v-else class="filterable-table">
         <caption class="sr-only">
           Column headers with buttons are sortable.
         </caption>
         <thead>
           <tr>
-            <th class="monster-table-header" :aria-sort="ariaSort.name">
-              <button @click="sort('name')">Name</button>
-            </th>
-            <th class="monster-table-header" :aria-sort="ariaSort.type">
-              <button @click="sort('type')">Type</button>
-            </th>
-            <th
-              class="monster-table-header"
-              :aria-sort="ariaSort.challenge_rating"
+            <sortable-table-header
+              :current-sort-dir="ariaSort.name"
+              @sort="(dir) => sort('name', dir)"
+              >Name</sortable-table-header
             >
-              <button @click="sort('challenge_rating')">CR</button>
-            </th>
-            <th class="monster-table-header" :aria-sort="ariaSort.size">
-              <button @click="sort('size')">Size</button>
-            </th>
-            <th class="monster-table-header" :aria-sort="ariaSort.hit_points">
-              <button @click="sort('hit_points')">Hit Points</button>
-            </th>
+            <sortable-table-header
+              :current-sort-dir="ariaSort.type"
+              @sort="(dir) => sort('type', dir)"
+              >Type</sortable-table-header
+            >
+            <sortable-table-header
+              :current-sort-dir="ariaSort.challenge_rating"
+              @sort="(dir) => sort('challenge_rating', dir)"
+              >CR</sortable-table-header
+            >
+            <sortable-table-header
+              :current-sort-dir="ariaSort.size"
+              @sort="(dir) => sort('size', dir)"
+              >Size</sortable-table-header
+            >
+            <sortable-table-header
+              :current-sort-dir="ariaSort.hit_points"
+              @sort="(dir) => sort('hit_points', dir)"
+              >Hit Points</sortable-table-header
+            >
           </tr>
         </thead>
         <tbody>
@@ -94,6 +101,7 @@
 import FilterInput from '~/components/FilterInput.vue';
 import FractionRenderer from '~/components/FractionRenderer.vue';
 import SourceTag from '~/components/SourceTag.vue';
+import SortableTableHeader from '~/components/SortableTableHeader.vue';
 import { useMainStore } from '~/store';
 
 export default {
@@ -110,7 +118,7 @@ export default {
     return {
       filter: '',
       currentSortProperty: 'name',
-      currentSortDir: 'asc',
+      currentSortDir: 'ascending',
     };
   },
   computed: {
@@ -128,7 +136,7 @@ export default {
       set: function () {
         return this.filteredMonsters.sort((a, b) => {
           let modifier = 1;
-          if (this.currentSortDir === 'desc') {
+          if (this.currentSortDir === 'descending') {
             modifier = -1;
           }
           if (a[this.currentSortProperty] < b[this.currentSortProperty]) {
@@ -168,10 +176,8 @@ export default {
     monsterListLength: function () {
       return Object.keys(this.monstersListed).length;
     },
-    sort: function (prop) {
-      if (prop === this.currentSortProperty) {
-        this.currentSortDir = this.currentSortDir === 'asc' ? 'desc' : 'asc';
-      }
+    sort: function (prop, value) {
+      this.currentSortDir = value;
       this.currentSortProperty = prop;
       this.monstersListed = {};
     },
@@ -183,7 +189,7 @@ export default {
     },
     getAriaSort(columName) {
       if (this.currentSortProperty === columName) {
-        return this.currentSortDir === 'asc' ? 'ascending' : 'descending';
+        return this.currentSortDir;
       }
       return null;
     },
@@ -193,7 +199,6 @@ export default {
 
 <style scoped lang="scss">
 .monster-table-header {
-  text-decoration: underline;
   cursor: pointer;
   vertical-align: baseline;
 

--- a/pages/monsters/monster-list.vue
+++ b/pages/monsters/monster-list.vue
@@ -109,7 +109,7 @@ export default {
   data() {
     return {
       filter: '',
-      currentSortProperty: 'challenge_rating',
+      currentSortProperty: 'name',
       currentSortDir: 'asc',
     };
   },

--- a/pages/monsters/monster-list.vue
+++ b/pages/monsters/monster-list.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container docs-container">
     <div class="filter-header-wrapper">
-      <h2 class="filter-header">Monster List</h2>
+      <h1 class="filter-header">Monster List</h1>
       <filter-input
         id="filter-monsters"
         ref="filter"

--- a/pages/spells/by-class/[charclass].vue
+++ b/pages/spells/by-class/[charclass].vue
@@ -1,14 +1,8 @@
 <template>
   <section class="container">
-    <h2 class="filter-header">
+    <h1 class="filter-header">
       <span class="title-case">{{ filter }} spells</span>
-      <p class="class-selector">
-        <!-- <label>Select a class: </label>
-        <select v-model="filter">
-          <option :key="charClass" :value="charClass" :selected="charClass.toLowerCase() == filter" v-for='charClass in available_classes'>{{charClass}}</option>
-        </select> -->
-      </p>
-    </h2>
+    </h1>
     <div :class="'three-column'">
       <p v-if="!spellListLength">No results</p>
       <ul v-for="level in spellsByLevel" :key="level.lvl" class="list--items">

--- a/pages/spells/spells-table.vue
+++ b/pages/spells/spells-table.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container">
     <div class="filter-header-wrapper">
-      <h2 class="filter-header">Spell List</h2>
+      <h1 class="filter-header">Spell List</h1>
       <filter-input
         id="filter-spells"
         ref="filter"
@@ -13,7 +13,7 @@
     </div>
     <div>
       <div>
-        <h3
+        <h2
           ref="results"
           class="sr-only"
           tabindex="-1"
@@ -22,7 +22,7 @@
           {{ spellsListed.length }}
           {{ spellsListed.length === 1 ? 'Result' : 'Results' }}
           <span v-if="filter.length > 0">&nbsp;for {{ filter }}</span>
-        </h3>
+        </h2>
         <div aria-live="assertive" aria-atomic="true" class="sr-only">
           <span v-if="spells.length && !spellsListed.length">No results.</span>
         </div>

--- a/pages/spells/spells-table.vue
+++ b/pages/spells/spells-table.vue
@@ -28,29 +28,32 @@
         </div>
       </div>
       <p v-if="!spells.length">Loading...</p>
-      <table v-else class="fiterable-table">
+      <table v-else class="filterable-table">
         <caption class="sr-only">
           Column headers with buttons are sortable.
         </caption>
         <thead>
           <tr>
-            <th class="spell-table-header" :aria-sort="ariaSort.name">
-              <button @click="sort('name')">Name</button>
-            </th>
-            <th class="spell-table-header" :aria-sort="ariaSort.school">
-              <button @click="sort('school')">School</button>
-            </th>
-            <th class="spell-table-header" :aria-sort="ariaSort.level_int">
-              <button @click="sort('level_int')">Level</button>
-            </th>
-            <th class="spell-table-header hide-mobile">
-              <button
-                :aria-sort="ariaSort.components"
-                @click="sort('components')"
-              >
-                Component
-              </button>
-            </th>
+            <sortable-table-header
+              :current-sort-dir="ariaSort.name"
+              @sort="(dir) => sort('name', dir)"
+              >Name</sortable-table-header
+            >
+            <sortable-table-header
+              :current-sort-dir="ariaSort.school"
+              @sort="(dir) => sort('school', dir)"
+              >School</sortable-table-header
+            >
+            <sortable-table-header
+              :current-sort-dir="ariaSort.level_int"
+              @sort="(dir) => sort('level_int', dir)"
+              >Level</sortable-table-header
+            >
+            <sortable-table-header
+              :current-sort-dir="ariaSort.components"
+              @sort="(dir) => sort('components', dir)"
+              >Components</sortable-table-header
+            >
             <th class="spell-table-header-class hide-mobile">Class</th>
           </tr>
         </thead>
@@ -116,7 +119,7 @@ export default {
     return {
       filter: '',
       currentSortProperty: 'name',
-      currentSortDir: 'asc',
+      currentSortDir: 'ascending',
     };
   },
   computed: {
@@ -130,7 +133,7 @@ export default {
       set: function () {
         return this.filteredSpells.sort((a, b) => {
           let modifier = 1;
-          if (this.currentSortDir === 'desc') {
+          if (this.currentSortDir === 'descending') {
             modifier = -1;
           }
           if (a[this.currentSortProperty] < b[this.currentSortProperty]) {
@@ -167,11 +170,9 @@ export default {
     spellListLength: function () {
       return Object.keys(this.spellsListed).length;
     },
-    sort: function (prop) {
-      if (prop === this.currentSortProperty) {
-        this.currentSortDir = this.currentSortDir === 'asc' ? 'desc' : 'asc';
-      }
+    sort: function (prop, dir) {
       this.currentSortProperty = prop;
+      this.currentSortDir = dir;
       this.spellsListed = {};
     },
     onFilterEnter: function () {
@@ -182,7 +183,7 @@ export default {
     },
     getAriaSort(columName) {
       if (this.currentSortProperty === columName) {
-        return this.currentSortDir === 'asc' ? 'ascending' : 'descending';
+        return this.currentSortDir === 'ascending' ? 'ascending' : 'descending';
       }
       return null;
     },
@@ -191,23 +192,6 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.spell-table-header {
-  vertical-align: baseline;
-
-  button {
-    border: none;
-    background: none;
-    padding: 0;
-    cursor: pointer;
-    text-decoration: underline;
-    font-weight: bold;
-  }
-}
-
-.spell-table-header-class {
-  vertical-align: baseline;
-}
-
 @media (max-width: 600px) {
   .hide-mobile {
     display: none;

--- a/pages/spells/spells-table.vue
+++ b/pages/spells/spells-table.vue
@@ -213,25 +213,4 @@ export default {
     display: none;
   }
 }
-
-.filter-header-wrapper {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-
-  row-gap: 0.5rem;
-  border-bottom: 3px solid #e74c3c;
-  padding-bottom: 0.25rem;
-
-  .filter-header {
-    border: none;
-    padding-bottom: 0;
-  }
-
-  @media (max-width: 600px) {
-    flex-direction: column;
-    align-items: flex-start;
-    padding-bottom: 0.25rem;
-  }
-}
 </style>


### PR DESCRIPTION
- Added additional information for screen readers.
- The placeholder for the filter-input now stays visible while typing.
- Added a sorting indicator to the table headers.
- Changed sortable table headers to include buttons to make them keyboard accessible.
- Changed the magic item list to show only one list of results while being filtered.
- Adjusted placeholder and source tag colors to meet the minimum contrast requirements.
- Changed the heading on those pages to also be a h1 element and removed the h1 from the "Open5e "in the top left. There should always be only one h1 element per page and it should be different between pages, so the h1 containing "Open5e" wasn't ideal.

Some of my sources for the changes:
([https://www.w3.org/WAI/ARIA/apg/patterns/table/examples/sortable-table/](url),  [https://www.scottohara.me/blog/2022/02/05/dynamic-results.html](url))