### PR TITLE
Fixed a bug with navbar displaying appendixes subroutes

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -219,12 +219,7 @@
           <!-- Running a Game -->
           <li>
             <nuxt-link to="/running/"> Appendixes </nuxt-link>
-            <ul
-              v-show="
-                useRoute().path.indexOf('/running') != -1 ||
-                containsAnyString(sectionGroups.Characters)
-              "
-            >
+            <ul v-show="useRoute().path.indexOf('/running') != -1">
               <li v-for="section in sectionGroups.Rules" :key="section.slug">
                 <nuxt-link :to="`/running/${section.slug}`">
                   {{ section.name }}


### PR DESCRIPTION
This is a quick fix for a UI bug in the navbar.

When viewing the following sub-routes, none of which are in the Appendixes section, the ul containing the Appendixes sub-routes (which should be hidden) is shown in addition to the Characters sub-routes

- https://open5e.com/sections/alignment
- https://open5e.com/sections/backgrounds
- https://open5e.com/sections/inspiration
- https://open5e.com/sections/languages

<img width="1184" src="https://github.com/open5e/open5e/assets/47755775/89d76503-681e-4c00-9ab2-b8997fca89e3">

I had a look at the template and found an odd looking OR in the v-show param of the Appendixes ul that didn't really make sense. It checking whether any of the sub-routes against those from the Characters section. After deleting the OR clause the problem appears to be fixed, and all of the other sub-routes ul's appear to be working as intended
