### PR TITLE
Fixes #384 - Added slash to API URL template string 

### DIFF
--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -150,7 +150,7 @@ export default {
       this.loading = true;
       return axios
         .get(
-          `${this.$nuxt.$config.public.apiUrl}/search?text=${this.$route.query.text}`
+          `${this.$nuxt.$config.public.apiUrl}/search/?text=${this.$route.query.text}`
         ) //you will need to enable CORS to make this work
         .then((response) => {
           this.results = response.data.results;


### PR DESCRIPTION
Fixes #384 

The problem wasn't with the prepending the slash, but that a slash was missing before the query param. I added the slash to the template string containing the endpoint in the search component. This appears to have fixed the problem.

<img width="914" src="https://github.com/open5e/open5e/assets/47755775/10f7129b-da2c-4270-88d5-ed84ae006756">
