### PR TITLE
Dark Mode

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -28,7 +28,6 @@ table {
   padding: 0 $pad-lg;
   h1 {
     font-size: 2rem;
-    color: $color-blood;
     &:not(:first-child) {
       margin-top: $pad-xl;
     }
@@ -120,7 +119,7 @@ h2.filter-header {
 }
 
 blockquote {
-  background-color: #eaeaea;
+  // background-color: #eaeaea;
   border-left: 0.75rem solid #999;
   padding: 0.1rem 1rem 1rem 1rem;
   margin-top: 1rem;

--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -119,7 +119,6 @@ h2.filter-header {
 }
 
 blockquote {
-  // background-color: #eaeaea;
   border-left: 0.75rem solid #999;
   padding: 0.1rem 1rem 1rem 1rem;
   margin-top: 1rem;

--- a/assets/_typography.scss
+++ b/assets/_typography.scss
@@ -2,7 +2,6 @@
 
 body {
   font-family: $font-family-base;
-  color: $color-darkness;
 }
 
 p {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -2,22 +2,11 @@
 @import 'typography';
 @import 'docs';
 
-// Conflicting with util classes in nav-links, re-add later for links in markdown
-
-// a {
-//   text-decoration: none;
-//   @apply text-blue-700 visited:text-purple-600 hover:underline;
-// }
-
 .side-note {
   @apply sticky right-3 float-right m-2 w-80 border border-blue-600 bg-blue-100 p-2 text-blue-900 dark:border-smoke dark:bg-basalt dark:text-white;
   h3 {
     @apply mt-0;
   }
-}
-
-.pad-r-sm {
-  margin-right: 0.25rem;
 }
 
 html {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -10,7 +10,7 @@
 // }
 
 .side-note {
-  @apply sticky right-3 float-right m-2 w-80 border border-blue-600 bg-blue-100 p-2 text-blue-900;
+  @apply sticky right-3 float-right m-2 w-80 border border-blue-600 bg-blue-100 p-2 text-blue-900 dark:border-smoke dark:bg-basalt dark:text-white;
   h3 {
     @apply mt-0;
   }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -2,10 +2,12 @@
 @import 'typography';
 @import 'docs';
 
-a {
-  text-decoration: none;
-  @apply text-blue-700 visited:text-purple-600 hover:underline;
-}
+// Conflicting with util classes in nav-links, re-add later for links in markdown
+
+// a {
+//   text-decoration: none;
+//   @apply text-blue-700 visited:text-purple-600 hover:underline;
+// }
 
 .side-note {
   @apply sticky right-3 float-right m-2 w-80 border border-blue-600 bg-blue-100 p-2 text-blue-900;

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -7,11 +7,11 @@
       <li
         v-for="crumb in crumbs"
         :key="crumb.url"
-        class="inline-flex h-10 items-center align-middle"
+        class="inline-flex h-10 items-center align-middle after:ml-4 after:text-blood after:content-['/'] last:after:content-['']"
       >
         <nuxt-link
           :to="crumb.url"
-          class="inline-flex items-center align-middle text-gray-700 visited:text-gray-700 hover:text-red-700"
+          class="inline-flex items-center align-middle text-gray-700 visited:text-gray-700 hover:text-red-700 dark:text-gray-200 dark:visited:text-gray-200 dark:hover:text-red-400"
         >
           <Icon
             v-if="crumb.title === 'Home'"
@@ -57,16 +57,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-li:after {
-  content: ' / ';
-  color: rgb(159 33 20);
-  display: inline;
-  margin-left: 1rem;
-}
-
-li:last-child:after {
-  content: '';
-}
-</style>

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="md:text-md mt-1 flex items-center border border-gray-200 py-1 align-middle text-sm font-semibold uppercase dark:border-granite md:ml-8 md:px-4"
+    class="md:text-md my-1 flex items-center border border-gray-200 px-2 py-0 align-middle text-sm font-semibold uppercase dark:border-granite md:ml-8 md:px-4 md:py-2"
     aria-label="breadcrumbs"
   >
     <ol class="space-x-3">

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="md:text-md mt-1 flex items-center border border-gray-200 py-1 align-middle text-sm font-semibold uppercase md:ml-8 md:px-4"
+    class="md:text-md mt-1 flex items-center border border-gray-200 py-1 align-middle text-sm font-semibold uppercase dark:border-granite md:ml-8 md:px-4"
     aria-label="breadcrumbs"
   >
     <ol class="space-x-3">

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="md:text-md my-1 flex items-center border border-gray-200 px-2 py-0 align-middle text-sm font-semibold uppercase dark:border-granite md:ml-8 md:px-4 md:py-2"
+    class="md:text-md my-1 flex items-center border border-gray-200 px-2 py-0 align-middle text-sm font-semibold uppercase dark:border-basalt md:ml-8 md:px-4 md:py-2"
     aria-label="breadcrumbs"
   >
     <ol class="space-x-3">

--- a/components/FilterInput.vue
+++ b/components/FilterInput.vue
@@ -10,7 +10,7 @@
       :id="id"
       ref="input"
       v-model="filterText"
-      class="filter-input"
+      class="filter-input bg-fog dark:bg-basalt dark:text-white"
       type="input"
       aria-description="Results will update as you type."
       @input.stop="onInput"

--- a/components/NavLink.vue
+++ b/components/NavLink.vue
@@ -1,0 +1,26 @@
+<template>
+  <nuxt-link
+    :class="`bold block px-4 py-3 text-white hover:bg-slate-800/40
+      hover:underline ${
+        useRoute().fullPath === to && 'bg-slate-800 font-bold'
+      }`"
+    :to="to"
+  >
+    <slot />
+  </nuxt-link>
+</template>
+
+<script>
+export default {
+  props: {
+    to: {
+      type: String,
+      default: '',
+    },
+    title: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>

--- a/components/NavLink.vue
+++ b/components/NavLink.vue
@@ -1,7 +1,7 @@
 <template>
   <nuxt-link
-    :class="`bold block w-full px-4  text-white hover:bg-slate-800/40
-      hover:underline ${
+    :class="`bold block w-full px-4  text-white hover:bg-slate-800/40 hover:underline
+      dark:hover:bg-slate-600/40 ${
         useRoute().fullPath === to && 'bg-slate-800 font-bold'
       } ${indent && 'py-1 pl-8'} ${!indent && 'py-3'}
       `"

--- a/components/NavLink.vue
+++ b/components/NavLink.vue
@@ -1,9 +1,10 @@
 <template>
   <nuxt-link
-    :class="`bold block px-4 py-3 text-white hover:bg-slate-800/40
+    :class="`bold block w-full px-4  text-white hover:bg-slate-800/40
       hover:underline ${
         useRoute().fullPath === to && 'bg-slate-800 font-bold'
-      }`"
+      } ${indent && 'py-1 pl-8'} ${!indent && 'py-3'}
+      `"
     :to="to"
   >
     <slot />
@@ -20,6 +21,10 @@ export default {
     title: {
       type: String,
       default: '',
+    },
+    indent: {
+      type: Boolean,
+      default: false,
     },
   },
 };

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -1,21 +1,52 @@
 <template>
-  <button
-    class="mx-2 mt-1 h-min rounded-full bg-fog px-4 py-3 hover:bg-smoke dark:bg-basalt dark:text-white dark:hover:bg-granite"
-    @click="handleClick"
-  >
-    <Icon name="heroicons:moon" class="text-center text-lg" />
-  </button>
+  <div>
+    <button
+      class="mx-2 mt-1 h-min rounded-full bg-fog px-4 py-3 hover:bg-smoke dark:hidden"
+      @click="handleClick"
+    >
+      <Icon
+        name="heroicons:moon"
+        class="hidden text-center text-lg dark:visible"
+      />
+    </button>
+    <button
+      class="mx-2 mt-1 hidden h-min rounded-full bg-basalt px-4 py-3 text-white hover:bg-granite dark:block"
+      @click="handleClick"
+    >
+      <Icon
+        name="heroicons:sun"
+        class="hidden text-center text-lg dark:visible"
+      />
+    </button>
+  </div>
 </template>
 
 <script>
+/* load theme preference before page and insert them into the head. This is to
+ * avoid flicker on load. 1st check local storage, then check media preferences
+ */
+useHead({
+  script: [
+    {
+      children: `if (localStorage.theme === "dark" || (!('theme' in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }`,
+    },
+  ],
+});
+
 export default {
   methods: {
     handleClick: () => {
       const body = document.documentElement;
       if (body.classList.contains('dark')) {
         body.classList.remove('dark');
+        localStorage.setItem('theme', 'light');
       } else {
         body.classList.add('dark');
+        localStorage.setItem('theme', 'dark');
       }
     },
   },

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -1,0 +1,20 @@
+<template>
+  <button class="sr-hidden" @click="handleClick">
+    <Icon name="heroicons:moon" />
+  </button>
+</template>
+
+<script>
+export default {
+  methods: {
+    handleClick: () => {
+      const body = document.documentElement;
+      if (body.classList.contains('dark')) {
+        body.classList.remove('dark');
+      } else {
+        body.classList.add('dark');
+      }
+    },
+  },
+};
+</script>

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -22,22 +22,24 @@
 </template>
 
 <script>
-/* load theme preference before page and insert them into the head. This is to
- * avoid flicker on load. 1st check local storage, then check media preferences
- */
-useHead({
-  script: [
-    {
-      children: `if (localStorage.theme === "dark" || (!('theme' in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+export default {
+  /* load theme preference before page and insert them into the head. This is to
+   * avoid flicker on load. 1st check local storage, then check media preferences
+   */
+
+  setup: function () {
+    useHead({
+      script: [
+        {
+          children: `if (localStorage.theme === "dark" || (!('theme' in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
       document.documentElement.classList.add('dark')
     } else {
       document.documentElement.classList.remove('dark')
     }`,
-    },
-  ],
-});
-
-export default {
+        },
+      ],
+    });
+  },
   methods: {
     handleClick: () => {
       const body = document.documentElement;

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -1,6 +1,9 @@
 <template>
-  <button class="sr-hidden" @click="handleClick">
-    <Icon name="heroicons:moon" />
+  <button
+    class="mx-2 mt-1 h-min rounded-full bg-fog px-4 py-3 hover:bg-smoke dark:bg-basalt dark:text-white dark:hover:bg-granite"
+    @click="handleClick"
+  >
+    <Icon name="heroicons:moon" class="text-center text-lg" />
   </button>
 </template>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="layout">
+  <div class="layout text-darkness">
     <SourcesModal :show="showModal" @close="showModal = false" />
-    <div class="app-wrapper" :class="{ 'show-sidebar': showSidebar }">
-      <div class="sidebar">
-        <nuxt-link to="/" class="logo">Open5e</nuxt-link>
+    <div class="app-wrapper bg-fog" :class="{ 'show-sidebar': showSidebar }">
+      <div class="sidebar flex bg-slate-700 text-white">
+        <nuxt-link to="/" class="logo bg-red">Open5e</nuxt-link>
         <div
           class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400"
           @click="showModal = true"
@@ -48,9 +48,10 @@
             <ul
               v-if="section.subroutes"
               v-show="useRoute().path.indexOf(section.route) != -1"
+              class="bg-slate-800/30 py-2"
             >
               <li v-for="page in section.subroutes" :key="page.slug">
-                <nav-link :to="`${section.route}/${page.slug}`">
+                <nav-link :to="`${section.route}/${page.slug}`" :indent="true">
                   {{ page.name }}
                 </nav-link>
               </li>
@@ -69,14 +70,22 @@
         </a>
       </div>
       <div class="content-wrapper bg-white">
-        <div class="mobile-header">
-          <div class="sidebar-toggle" @click="toggleSidebar" />
+        <div class="mobile-header bg-red text-white">
+          <div class="sidebar-toggle hover:bg-blood" @click="toggleSidebar" />
           <nuxt-link to="/" class="logo"> Open5e </nuxt-link>
           <div class="spacer" />
         </div>
-        <div v-show="showSidebar" class="shade" @click="hideSidebar" />
+        <div
+          v-show="showSidebar"
+          class="shade bg-basalt/50"
+          @click="hideSidebar"
+        />
         <breadcrumb-links />
         <nuxt-page />
+
+        <footer class="mt-4 border-t-2 border-fog pt-4 text-center text-sm">
+          <nuxt-link to="/legal">Content provided under the OGL 1.0a</nuxt-link>
+        </footer>
       </div>
     </div>
   </div>
@@ -118,6 +127,7 @@ export default {
       return this.store.isLoadingData;
     },
 
+    // returns an array of routes that the cmpnt iterates thru to create nav
     routes: function () {
       return [
         {
@@ -185,8 +195,12 @@ export default {
           title: 'Running a Game',
           route: '/running',
           subroutes: this.store.sections.filter(
-            (page) => page.parent === 'Running a Game'
+            (page) => page.parent === 'Rules'
           ),
+        },
+        {
+          title: 'API Docs',
+          route: '/api-docs',
         },
       ];
     },
@@ -255,7 +269,6 @@ export default {
   align-content: stretch;
   height: 100vh;
   width: 100vw;
-  background: $color-fog;
   position: relative;
 }
 
@@ -272,49 +285,16 @@ export default {
   }
 }
 
-// .input-search {
-//   position: sticky;
-//   top: 0;
-//   width: 100%;
-//   background: $color-blood;
-//   color: white;
-//   padding: 1rem;
-//   border: none;
-//   font-size: $font-size-base;
-//   outline: none;
-//   z-index: 2;
-
-//   &::placeholder {
-//     color: white;
-//     opacity: 0.6;
-//   }
-// }
-
-footer {
-  margin-top: 1rem;
-  font-size: 0.8rem;
-  display: block;
-  text-align: center;
-  padding-top: 1rem;
-  border-top: 1px solid $color-fog;
-}
-
 .mobile-header {
   display: none;
   width: calc(100% + 4rem);
   top: -1rem;
   height: 3rem;
-  background-color: $color-fireball;
   position: sticky;
-  color: white;
   flex-direction: row;
   justify-content: space-between;
   margin: (-$content-padding-y) (-$content-padding-x) 0;
   z-index: 60;
-
-  a {
-    color: white;
-  }
 
   .sidebar-toggle {
     display: flex;
@@ -326,11 +306,7 @@ footer {
     background-size: 50%;
     background-repeat: no-repeat;
     background-position: center;
-
-    &:hover {
-      background-color: $color-blood;
-      cursor: pointer;
-    }
+    cursor: pointer;
   }
 
   .logo {
@@ -346,14 +322,12 @@ footer {
 }
 
 .sidebar {
-  @apply bg-slate-700 text-white;
   width: $sidebar-width;
   min-width: $sidebar-width;
   overflow-y: auto;
   font-size: 15px;
   position: relative;
   z-index: 50;
-  display: flex;
   flex-direction: column;
 
   .sidebar-link {
@@ -369,24 +343,12 @@ footer {
 
   .logo {
     display: block;
-    background-color: $color-fireball;
     padding: 1rem 3rem 1rem 1rem;
     cursor: pointer;
     margin-top: 0;
     font-family: Lora, serif;
     font-weight: 600;
     font-size: 2em;
-  }
-
-  // Style the root elements of the sidebar only
-  > ul > li {
-    // and the child elements of the sidebar (eg classes under "class")
-    ul {
-      @apply bg-slate-800/30 py-2;
-      & > li > a {
-        @apply py-1 pl-8 pr-4;
-      }
-    }
   }
 }
 
@@ -398,7 +360,6 @@ footer {
     left: 0;
     width: 100vw;
     height: 100vh;
-    background: rgba($color-basalt, 0.5);
     z-index: 48;
   }
 
@@ -436,7 +397,6 @@ footer {
       overflow-x: visible;
 
       .side-note {
-        // position: absolute;
         right: 2rem;
       }
     }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -93,12 +93,6 @@
 
         <!-- Main content -->
         <nuxt-page class="text-darkness dark:text-white" />
-
-        <footer
-          class="dark mt-4 border-t border-fog pt-4 text-center text-sm dark:border-granite"
-        >
-          <nuxt-link to="/legal">Content provided under the OGL 1.0a</nuxt-link>
-        </footer>
       </div>
     </div>
   </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,9 +6,9 @@
       :class="{ 'show-sidebar': showSidebar }"
     >
       <div class="sidebar flex bg-slate-700 text-white dark:bg-slate-900">
-        <nuxt-link to="/" class="logo bg-red dark:bg-blood">Open5e</nuxt-link>
+        <nuxt-link to="/" class="logo bg-red">Open5e</nuxt-link>
         <div
-          class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400 dark:bg-red-700"
+          class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400 dark:bg-red-700 dark:hover:bg-red-600"
           @click="showModal = true"
         >
           <span v-if="documents.length">
@@ -37,7 +37,7 @@
           </div>
           <input
             v-model="searchText"
-            class="w-full bg-red-700 px-4 py-4 placeholder-white/80 placeholder:font-semibold focus:border-0 focus:bg-red-800 focus:outline-none dark:bg-red-800 dark:focus:bg-red-900"
+            class="w-full bg-red-700 px-4 py-4 placeholder-white/80 placeholder:font-semibold focus:border-0 focus:bg-red-800 focus:outline-none dark:bg-red-800 dark:focus:bg-red-600"
             placeholder="Search Open5e"
             @keyup.enter="doSearch(searchText)"
           />
@@ -91,7 +91,7 @@
         <nuxt-page class="text-darkness dark:text-white" />
 
         <footer
-          class="dark mt-4 border-t-2 border-fog pt-4 text-center text-sm dark:border-gray-700"
+          class="dark mt-4 border-t border-fog pt-4 text-center text-sm dark:border-granite"
         >
           <nuxt-link to="/legal">Content provided under the OGL 1.0a</nuxt-link>
         </footer>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -88,6 +88,7 @@
           @click="hideSidebar"
         />
         <breadcrumb-links />
+        <theme-switcher />
         <nuxt-page class="text-darkness dark:text-white" />
 
         <footer

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -73,7 +73,6 @@
         </a>
       </div>
 
-      <!-- Main content -->
       <div
         class="content-wrapper bg-white text-darkness dark:bg-darkness dark:text-white"
       >
@@ -87,8 +86,12 @@
           class="shade bg-basalt/50"
           @click="hideSidebar"
         />
-        <breadcrumb-links />
-        <theme-switcher />
+        <div class="flex">
+          <breadcrumb-links class="flex-grow" />
+          <theme-switcher class="inline-block" />
+        </div>
+
+        <!-- Main content -->
         <nuxt-page class="text-darkness dark:text-white" />
 
         <footer

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="layout text-darkness">
     <SourcesModal :show="showModal" @close="showModal = false" />
-    <div class="app-wrapper bg-fog" :class="{ 'show-sidebar': showSidebar }">
+    <div
+      class="app-wrapper bg-fog dark:bg-darkness"
+      :class="{ 'show-sidebar': showSidebar }"
+    >
       <div class="sidebar flex bg-slate-700 text-white">
         <nuxt-link to="/" class="logo bg-red">Open5e</nuxt-link>
         <div
@@ -69,7 +72,11 @@
           />
         </a>
       </div>
-      <div class="content-wrapper bg-white">
+
+      <!-- Main content -->
+      <div
+        class="content-wrapper bg-white text-darkness dark:bg-darkness dark:text-white"
+      >
         <div class="mobile-header bg-red text-white">
           <div class="sidebar-toggle hover:bg-blood" @click="toggleSidebar" />
           <nuxt-link to="/" class="logo"> Open5e </nuxt-link>
@@ -81,9 +88,11 @@
           @click="hideSidebar"
         />
         <breadcrumb-links />
-        <nuxt-page />
+        <nuxt-page class="text-darkness dark:text-white" />
 
-        <footer class="mt-4 border-t-2 border-fog pt-4 text-center text-sm">
+        <footer
+          class="dark mt-4 border-t-2 border-fog pt-4 text-center text-sm dark:border-gray-700"
+        >
           <nuxt-link to="/legal">Content provided under the OGL 1.0a</nuxt-link>
         </footer>
       </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,10 +5,10 @@
       class="app-wrapper bg-fog dark:bg-darkness"
       :class="{ 'show-sidebar': showSidebar }"
     >
-      <div class="sidebar flex bg-slate-700 text-white">
-        <nuxt-link to="/" class="logo bg-red">Open5e</nuxt-link>
+      <div class="sidebar flex bg-slate-700 text-white dark:bg-slate-900">
+        <nuxt-link to="/" class="logo bg-red dark:bg-blood">Open5e</nuxt-link>
         <div
-          class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400"
+          class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400 dark:bg-red-700"
           @click="showModal = true"
         >
           <span v-if="documents.length">
@@ -37,7 +37,7 @@
           </div>
           <input
             v-model="searchText"
-            class="w-full bg-red-700 px-4 py-4 placeholder-white/80 placeholder:font-semibold focus:border-0 focus:bg-red-800 focus:outline-none"
+            class="w-full bg-red-700 px-4 py-4 placeholder-white/80 placeholder:font-semibold focus:border-0 focus:bg-red-800 focus:outline-none dark:bg-red-800 dark:focus:bg-red-900"
             placeholder="Search Open5e"
             @keyup.enter="doSearch(searchText)"
           />
@@ -45,7 +45,7 @@
 
         <!-- Navigation Links -->
 
-        <ul class="bg-slate-700 text-inherit text-white">
+        <ul class="text-inherit text-white">
           <li v-for="section in routes" :key="section.title">
             <nav-link :to="section.route"> {{ section.title }} </nav-link>
             <ul

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,12 +1,17 @@
 <template>
-  <div class="layout text-darkness">
+  <div class="overflow-hidden text-darkness">
     <SourcesModal :show="showModal" @close="showModal = false" />
     <div
-      class="app-wrapper bg-fog dark:bg-darkness"
+      class="app-wrapper relative h-screen w-screen bg-white dark:bg-darkness"
       :class="{ 'show-sidebar': showSidebar }"
     >
-      <div class="sidebar flex bg-slate-700 text-white dark:bg-slate-900">
-        <nuxt-link to="/" class="logo bg-red">Open5e</nuxt-link>
+      <!-- Sidebar -->
+      <div
+        class="sidebar relative z-50 flex flex-col bg-slate-700 text-white dark:bg-slate-900"
+      >
+        <!-- Logo -->
+        <nuxt-link to="/" class="logo bg-red p-5 text-3xl">Open5e</nuxt-link>
+
         <div
           class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400 dark:bg-red-700 dark:hover:bg-red-600"
           @click="showModal = true"
@@ -44,7 +49,6 @@
         </div>
 
         <!-- Navigation Links -->
-
         <ul class="text-inherit text-white">
           <li v-for="section in routes" :key="section.title">
             <nav-link :to="section.route"> {{ section.title }} </nav-link>
@@ -63,27 +67,43 @@
         </ul>
 
         <!-- Patron Banner -->
-
-        <a class="sidebar-link" href="https://www.patreon.com/open5e">
+        <a
+          class="mt-auto inline-block self-end"
+          href="https://www.patreon.com/open5e"
+        >
           <img
             src="/img/patron-badge.png"
-            class="sidebar-image"
+            class="block w-full"
             alt="Become a patron! Keep Open5e ad free!"
           />
         </a>
       </div>
 
+      <!-- Page central column -->
       <div
         class="content-wrapper bg-white text-darkness dark:bg-darkness dark:text-white"
       >
-        <div class="mobile-header bg-red text-white">
-          <div class="sidebar-toggle hover:bg-blood" @click="toggleSidebar" />
-          <nuxt-link to="/" class="logo"> Open5e </nuxt-link>
-          <div class="spacer" />
+        <!-- Mobile Header -->
+        <div
+          class="mobile-header sticky z-60 h-12 flex-row justify-between bg-red text-3xl dark:bg-red-800"
+        >
+          <div
+            class="sidebar-toggle flex h-full w-12 cursor-pointer items-center justify-center hover:bg-blood"
+            @click="toggleSidebar"
+          />
+          <nuxt-link
+            to="/"
+            class="logo mb-1 self-center font-serif text-lg font-bold text-white"
+          >
+            Open5e
+          </nuxt-link>
+          <div class="h-12 w-12" />
         </div>
+
+        <!-- Shade: fades out main content when sidebar expanded on mobile -->
         <div
           v-show="showSidebar"
-          class="shade bg-basalt/50"
+          class="shade fixed left-0 top-0 z-48 h-full w-full bg-basalt/50"
           @click="hideSidebar"
         />
         <div class="flex">
@@ -91,8 +111,8 @@
           <theme-switcher class="inline-block" />
         </div>
 
-        <!-- Main content -->
-        <nuxt-page class="text-darkness dark:text-white" />
+        <!-- Main page content -->
+        <nuxt-page class="page-content text-darkness dark:text-white" />
       </div>
     </div>
   </div>
@@ -112,6 +132,7 @@ export default {
       showSidebar: false,
       showModal: false,
       spellcastingClasses: [
+        { name: 'Spells by Class', slug: 'by-class' },
         { name: 'Bard Spells', slug: 'by-class/bard' },
         { name: 'Cleric Spells', slug: 'by-class/cleric' },
         { name: 'Druid Spells', slug: 'by-class/druid' },
@@ -262,10 +283,6 @@ export default {
 <style lang="scss">
 @import '../assets/main';
 
-.layout {
-  overflow: hidden;
-}
-
 .shade {
   display: none;
 }
@@ -274,9 +291,6 @@ export default {
   display: flex;
   flex-direction: row;
   align-content: stretch;
-  height: 100vh;
-  width: 100vw;
-  position: relative;
 }
 
 .content-wrapper {
@@ -284,94 +298,44 @@ export default {
   overflow: auto;
   flex-grow: 1;
   max-width: 60rem;
-
-  .sticky-header {
-    position: sticky;
-    top: 0;
-    z-index: 40;
+}
+.page-content {
+  * > a {
+    @apply text-indigo-600 hover:text-blood hover:underline dark:text-indigo-200 dark:hover:text-red;
   }
+}
+
+.logo {
+  font-family: Lora, serif;
+  display: block;
 }
 
 .mobile-header {
   display: none;
   width: calc(100% + 4rem);
-  top: -1rem;
-  height: 3rem;
-  position: sticky;
-  flex-direction: row;
-  justify-content: space-between;
   margin: (-$content-padding-y) (-$content-padding-x) 0;
-  z-index: 60;
-
-  .sidebar-toggle {
-    display: flex;
-    height: 100%;
-    width: 3rem;
-    justify-content: center;
-    align-items: center;
-    background-image: url('/img/menu-button.png');
-    background-size: 50%;
-    background-repeat: no-repeat;
-    background-position: center;
-    cursor: pointer;
-  }
-
-  .logo {
-    display: inline-block;
-    margin: 0;
-    padding: 0;
-  }
-
-  .spacer {
-    width: 3rem;
-    height: 3rem;
-  }
 }
 
 .sidebar {
   width: $sidebar-width;
   min-width: $sidebar-width;
   overflow-y: auto;
-  font-size: 15px;
-  position: relative;
-  z-index: 50;
-  flex-direction: column;
-
-  .sidebar-link {
-    display: inline-block;
-    align-self: flex-end;
-    margin-top: auto;
-  }
-
-  .sidebar-image {
-    width: 100%;
-    display: block;
-  }
-
-  .logo {
-    display: block;
-    padding: 1rem 3rem 1rem 1rem;
-    cursor: pointer;
-    margin-top: 0;
-    font-family: Lora, serif;
-    font-weight: 600;
-    font-size: 2em;
-  }
 }
 
+.sidebar-toggle {
+  background-image: url('/img/menu-button.png');
+  background-size: 50%;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+// These should be refactored using Tailwind breakpoints
 @media (max-width: 600px) {
   .shade {
     display: block;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    z-index: 48;
   }
 
   .app-wrapper {
-    position: relative;
     margin-left: -$sidebar-width;
     transition: margin-left 250ms ease;
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,7 +3,7 @@
     <SourcesModal :show="showModal" @close="showModal = false" />
     <div class="app-wrapper" :class="{ 'show-sidebar': showSidebar }">
       <div class="sidebar">
-        <nuxt-link to="/" class="logo"> Open5e </nuxt-link>
+        <nuxt-link to="/" class="logo">Open5e</nuxt-link>
         <div
           class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400"
           @click="showModal = true"
@@ -39,200 +39,27 @@
             @keyup.enter="doSearch(searchText)"
           />
         </div>
-        <ul v-if="sections && races && classes">
-          <!-- Characters -->
-          <li>
-            <nuxt-link to="/characters"> Characters </nuxt-link>
-            <ul v-show="useRoute().path.indexOf('/characters') != -1">
-              <li v-for="section in charSections" :key="section.slug">
-                <nuxt-link :to="`/characters/${section.slug}`">
-                  {{ section.name }}
-                </nuxt-link>
-              </li>
-            </ul>
-          </li>
-          <!-- Classes -->
-          <li>
-            <nuxt-link to="/classes"> Classes </nuxt-link>
-            <ul v-show="useRoute().path.indexOf('/classes') != -1">
-              <li v-for="charClass in classes" :key="charClass.slug">
-                <nuxt-link
-                  :class="{
-                    'router-link-active':
-                      useRoute().path.indexOf(`/classes/${charClass.slug}`) ===
-                      0,
-                  }"
-                  :to="`/classes/${charClass.slug}`"
-                >
-                  {{ charClass.name }}
-                </nuxt-link>
-              </li>
-            </ul>
-          </li>
-          <!-- Races -->
-          <li>
-            <nuxt-link to="/races"> Races </nuxt-link>
-            <ul v-if="races" v-show="useRoute().path.indexOf('/races') != -1">
-              <li v-for="race in races" :key="race.slug">
-                <nuxt-link :to="`/races/${race.slug}`">
-                  {{ race.name }}
-                </nuxt-link>
-              </li>
-            </ul>
-          </li>
 
-          <!-- Backgrounds -->
-          <li>
-            <nuxt-link
-              to="/backgrounds"
-              :class="{
-                'router-link-active':
-                  useRoute().path.indexOf('/backgrounds') === 0,
-              }"
-            >
-              Backgrounds
-            </nuxt-link>
-          </li>
+        <!-- Navigation Links -->
 
-          <li>
-            <nuxt-link
-              to="/feats"
-              tag="a"
-              :class="{
-                'router-link-active': useRoute().path.indexOf('/feats') === 0,
-              }"
-            >
-              Feats
-            </nuxt-link>
-          </li>
-
-          <!-- Combat -->
-          <li v-if="combatSections.length > 0">
-            <nuxt-link to="/combat"> Combat </nuxt-link>
+        <ul class="bg-slate-700 text-inherit text-white">
+          <li v-for="section in routes" :key="section.title">
+            <nav-link :to="section.route"> {{ section.title }} </nav-link>
             <ul
-              v-if="combatSections"
-              v-show="useRoute().path.indexOf('/combat/') != -1"
+              v-if="section.subroutes"
+              v-show="useRoute().path.indexOf(section.route) != -1"
             >
-              <li v-for="section in sectionGroups.Combat" :key="section.slug">
-                <nuxt-link :to="`/combat/${section.slug}`">
-                  {{ section.name }}
-                </nuxt-link>
+              <li v-for="page in section.subroutes" :key="page.slug">
+                <nav-link :to="`${section.route}/${page.slug}`">
+                  {{ page.name }}
+                </nav-link>
               </li>
             </ul>
-          </li>
-
-          <!-- Equipment -->
-          <li>
-            <nuxt-link to="/equipment"> Equipment </nuxt-link>
-            <ul v-show="useRoute().path.indexOf('/equipment/') != -1">
-              <li
-                v-for="section in sectionGroups.Equipment"
-                :key="section.slug"
-              >
-                <nuxt-link :to="`/equipment/${section.slug}`">
-                  {{ section.name }}
-                </nuxt-link>
-              </li>
-            </ul>
-          </li>
-          <!-- Magic Items -->
-          <li>
-            <nuxt-link
-              :class="{
-                'router-link-active':
-                  useRoute().path.indexOf('/magic-items') === 0,
-              }"
-              to="/magic-items"
-            >
-              Magic Items
-            </nuxt-link>
-          </li>
-          <!-- Spells -->
-          <li>
-            <nuxt-link
-              :class="{
-                'router-link-active': useRoute().path.indexOf('/spells') === 0,
-              }"
-              to="/spells"
-            >
-              Spells
-            </nuxt-link>
-            <ul v-show="useRoute().path.indexOf('/spells') !== -1">
-              <li>
-                <nuxt-link to="/spells/by-class/bard"> Bard Spells </nuxt-link>
-              </li>
-              <li>
-                <nuxt-link to="/spells/by-class/cleric">
-                  Cleric Spells
-                </nuxt-link>
-              </li>
-              <li>
-                <nuxt-link to="/spells/by-class/druid">
-                  Druid Spells
-                </nuxt-link>
-              </li>
-              <li>
-                <nuxt-link to="/spells/by-class/paladin">
-                  Paladin Spells
-                </nuxt-link>
-              </li>
-              <li>
-                <nuxt-link to="/spells/by-class/sorcerer">
-                  Sorcerer Spells
-                </nuxt-link>
-              </li>
-              <li>
-                <nuxt-link to="/spells/by-class/wizard">
-                  Wizard Spells
-                </nuxt-link>
-              </li>
-              <li>
-                <nuxt-link to="/spells/by-class/warlock">
-                  Warlock Spells
-                </nuxt-link>
-              </li>
-            </ul>
-          </li>
-          <!-- Monsters -->
-          <li>
-            <nuxt-link
-              :class="{
-                'router-link-active':
-                  useRoute().path.indexOf('/monsters') === 0,
-              }"
-              to="/monsters"
-            >
-              Monsters
-            </nuxt-link>
-          </li>
-          <!-- Gameplay Mechanics -->
-          <li>
-            <nuxt-link to="/gameplay-mechanics/">
-              Gameplay Mechanics
-            </nuxt-link>
-            <ul v-show="useRoute().path.indexOf('/gameplay-mechanics/') !== -1">
-              <li v-for="section in mechanicsSections" :key="section.slug">
-                <nuxt-link :to="`/gameplay-mechanics/${section.slug}`">
-                  {{ section.name }}
-                </nuxt-link>
-              </li>
-            </ul>
-          </li>
-          <!-- Running a Game -->
-          <li>
-            <nuxt-link to="/running/">Running a Game</nuxt-link>
-            <ul v-show="useRoute().path.indexOf('/running') != -1">
-              <li v-for="section in sectionGroups.Rules" :key="section.slug">
-                <nuxt-link :to="`/running/${section.slug}`">
-                  {{ section.name }}
-                </nuxt-link>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <nuxt-link to="/api-docs"> API Docs </nuxt-link>
           </li>
         </ul>
+
+        <!-- Patron Banner -->
+
         <a class="sidebar-link" href="https://www.patreon.com/open5e">
           <img
             src="/img/patron-badge.png"
@@ -241,7 +68,7 @@
           />
         </a>
       </div>
-      <div class="content-wrapper">
+      <div class="content-wrapper bg-white">
         <div class="mobile-header">
           <div class="sidebar-toggle" @click="toggleSidebar" />
           <nuxt-link to="/" class="logo"> Open5e </nuxt-link>
@@ -257,14 +84,6 @@
 
 <script>
 import { useMainStore } from '../store/index';
-Array.prototype.groupBy = function (prop) {
-  return this.reduce(function (groups, item) {
-    const val = item[prop];
-    groups[val] = groups[val] || [];
-    groups[val].push(item);
-    return groups;
-  }, {});
-};
 
 export default {
   setup() {
@@ -276,58 +95,103 @@ export default {
       searchText: this.$route.query.text,
       showSidebar: false,
       showModal: false,
+      spellcastingClasses: [
+        { name: 'Bard Spells', slug: 'by-class/bard' },
+        { name: 'Cleric Spells', slug: 'by-class/cleric' },
+        { name: 'Druid Spells', slug: 'by-class/druid' },
+        { name: 'Paladin Spells', slug: 'by-class/paladin' },
+        { name: 'Ranger Spells', slug: 'by-class/ranger' },
+        { name: 'Wizard Spells', slug: 'by-class/wizard' },
+        { name: 'Warlock Spells', slug: 'by-class/warlock' },
+      ],
     };
   },
   computed: {
-    classes: function () {
-      return this.store.classes;
-    },
-    sections: function () {
-      return this.store.sections;
-    },
-    races: function () {
-      return this.store.races;
-    },
     documents: function () {
       return this.store.documents;
     },
     sourceSelection: function () {
       return this.store.sourceSelection;
     },
-    sectionGroups: function () {
-      let groupedSections = this.sections.groupBy('parent');
-      return groupedSections;
-    },
+
     isLoadingData: function () {
       return this.store.isLoadingData;
     },
-    charSections: function () {
-      if (!this.sectionGroups.hasOwnProperty('Characters')) {
-        return [];
-      }
 
-      let results = this.sectionGroups['Characters'].concat(
-        this.sectionGroups['Character Advancement']
-      );
-
-      return results.sort(function (a, b) {
-        if (a.slug < b.slug) {
-          return -1;
-        } else if (a.slug > b.slug) {
-          return 1;
-        } else {
-          return 0;
-        }
-      });
-    },
-    combatSections: function () {
-      return this.sectionGroups['Combat'] ?? [];
-    },
-
-    mechanicsSections: function () {
-      return this.sectionGroups['Gameplay Mechanics'] ?? [];
+    routes: function () {
+      return [
+        {
+          title: 'Characters',
+          route: '/characters',
+          subroutes: this.store.sections.filter(
+            (page) =>
+              page.parent === 'Characters' ||
+              page.parent === 'Character Advancement'
+          ),
+        },
+        {
+          title: 'Classes',
+          route: '/classes',
+          subroutes: this.store.classes,
+        },
+        {
+          title: 'Races',
+          route: '/races',
+          subroutes: this.store.races,
+        },
+        {
+          title: 'Backgrounds',
+          route: '/backgrounds',
+        },
+        {
+          title: 'Feats',
+          route: '/feats',
+        },
+        {
+          title: 'Combat',
+          route: '/combat',
+          subroutes: this.store.sections.filter(
+            (page) => page.parent === 'Combat'
+          ),
+        },
+        {
+          title: 'Equipment',
+          route: '/equipment',
+          subroutes: this.store.sections.filter(
+            (page) => page.parent === 'Equipment'
+          ),
+        },
+        {
+          title: 'Magic Items',
+          route: '/magic-items',
+        },
+        {
+          title: 'Spells',
+          route: '/spells',
+          subroutes: this.spellcastingClasses,
+        },
+        {
+          title: 'Monsters',
+          route: '/monsters',
+        },
+        {
+          title: 'Gameplay Mechanics',
+          route: '/gameplay-mechanics',
+          subroutes: this.store.sections.filter(
+            (page) => page.parent === 'Gameplay Mechanics'
+          ),
+        },
+        {
+          title: 'Running a Game',
+          route: '/running',
+          subroutes: this.store.sections.filter(
+            (page) => page.parent === 'Running a Game'
+          ),
+        },
+      ];
     },
   },
+
   watch: {
     $route(to, from) {
       this.showSidebar = false;
@@ -399,7 +263,6 @@ export default {
   padding: $content-padding-y $content-padding-x;
   overflow: auto;
   flex-grow: 1;
-  background: white;
   max-width: 60rem;
 
   .sticky-header {
@@ -409,23 +272,23 @@ export default {
   }
 }
 
-.input-search {
-  position: sticky;
-  top: 0;
-  width: 100%;
-  background: $color-blood;
-  color: white;
-  padding: 1rem;
-  border: none;
-  font-size: $font-size-base;
-  outline: none;
-  z-index: 2;
+// .input-search {
+//   position: sticky;
+//   top: 0;
+//   width: 100%;
+//   background: $color-blood;
+//   color: white;
+//   padding: 1rem;
+//   border: none;
+//   font-size: $font-size-base;
+//   outline: none;
+//   z-index: 2;
 
-  &::placeholder {
-    color: white;
-    opacity: 0.6;
-  }
-}
+//   &::placeholder {
+//     color: white;
+//     opacity: 0.6;
+//   }
+// }
 
 footer {
   margin-top: 1rem;
@@ -493,10 +356,6 @@ footer {
   display: flex;
   flex-direction: column;
 
-  a {
-    color: white;
-  }
-
   .sidebar-link {
     display: inline-block;
     align-self: flex-end;
@@ -519,29 +378,8 @@ footer {
     font-size: 2em;
   }
 
-  // General sidebar styling
-  ul {
-    li {
-      a {
-        &:hover {
-          opacity: 1;
-          @apply hover:bg-slate-800/40;
-        }
-
-        &.router-link-active {
-          font-weight: bold;
-          opacity: 1;
-          @apply bg-slate-900/60;
-        }
-      }
-    }
-  }
   // Style the root elements of the sidebar only
   > ul > li {
-    a {
-      display: block;
-      @apply px-4 py-3;
-    }
     // and the child elements of the sidebar (eg classes under "class")
     ul {
       @apply bg-slate-800/30 py-2;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -71,6 +71,7 @@
     </p>
     <a href="https://www.patreon.com/open5e" class="external-button">
       <img
+        class="dark:rounded-lg"
         src="/img/patron-button.png"
         alt="Become a patron! Keep Open5e ad free!"
       />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -71,7 +71,7 @@
     </p>
     <a href="https://www.patreon.com/open5e" class="external-button">
       <img
-        class="dark:rounded-lg"
+        class="rounded-lg"
         src="/img/patron-button.png"
         alt="Become a patron! Keep Open5e ad free!"
       />
@@ -116,11 +116,6 @@ export default {
 </script>
 
 <style lang="scss">
-.monster-block,
-.spell-block {
-  margin-top: 1rem;
-}
-
 .external-button {
   margin-top: 0.6rem;
   zoom: 40%;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -56,12 +56,12 @@
       <b>VueJs UI layer.</b> A Vue.js single-page app, using the Nuxt framework.
     </p>
 
-    <a href="https://github.com/open5e/open5e" class="external-button mr-2"
-      ><img src="/img/github-website-button.png" alt="Open5e site repo"
-    /></a>
-    <a href="https://github.com/open5e/open5e-api" class="external-button"
-      ><img src="/img/github-api-button.png" alt="Open5e API Repo"
-    /></a>
+    <a href="https://github.com/open5e/open5e" class="external-button mr-2">
+      <img src="/img/github-website-button.png" alt="Open5e site repo" />
+    </a>
+    <a href="https://github.com/open5e/open5e-api" class="external-button">
+      <img src="/img/github-api-button.png" alt="Open5e API Repo" />
+    </a>
 
     <h3>Support us on Patreon</h3>
     <p>
@@ -69,20 +69,21 @@
       on donations and patrons to pay for our server costs, and to fund an
       increasing effort to fill out flavor text and add art.
     </p>
-    <a href="https://www.patreon.com/open5e" class="external-button"
-      ><img
+    <a href="https://www.patreon.com/open5e" class="external-button">
+      <img
         src="/img/patron-button.png"
         alt="Become a patron! Keep Open5e ad free!"
-    /></a>
+      />
+    </a>
 
     <h3>Join the Discord</h3>
     <p>
       Join us to chat, talk about development, and share neat homebrew. We don't
       bite!
     </p>
-    <a href="https://discord.gg/QXqF6gSVqB" class="external-button"
-      ><img src="/img/discord-button.png" alt="Join our discord"
-    /></a>
+    <a href="https://discord.gg/QXqF6gSVqB" class="external-button">
+      <img src="/img/discord-button.png" alt="Join our discord" />
+    </a>
 
     <h2>The API</h2>
 

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -17,7 +17,7 @@
       <p><b>Armor Class</b> {{ monster.armor_class }}</p>
       <p><b>Hit Points</b> {{ monster.hit_points }} ({{ monster.hit_dice }})</p>
       <p>
-        <b class="pad-r-sm">Speed</b>
+        <b class="pr-1">Speed</b>
         <span
           v-for="(speed, key, index) in monster.speed"
           v-show="key !== 'hover'"
@@ -65,32 +65,28 @@
         </div>
         <div class="ability-block">
           <span class="ability-name">WIS</span>
-          <span class="ability-score"
-            >{{ monster.wisdom }} (<stat-bonus :stat="monster.wisdom" />)</span
-          >
+          <span class="ability-score">
+            {{ monster.wisdom }} (<stat-bonus :stat="monster.wisdom" />)
+          </span>
         </div>
         <div class="ability-block">
           <span class="ability-name">CHA</span>
-          <span class="ability-score"
-            >{{ monster.charisma }} (<stat-bonus
-              :stat="monster.charisma"
-            />)</span
-          >
+          <span class="ability-score">
+            {{ monster.charisma }} (<stat-bonus :stat="monster.charisma" />)
+          </span>
         </div>
       </div>
       <hr />
       <p v-if="getSaves">
-        <b class="pad-r-sm">Saving Throws</b>
+        <b class="pr-1">Saving Throws</b>
         <span v-for="(save, index) in getSaves" :key="save.name">
           {{ save.name }}
-          <stat-bonus :stat="save.val" :type="save.type" /><span
-            v-show="index < getSaves.length - 1"
-            >,
-          </span>
+          <stat-bonus :stat="save.val" :type="save.type" />
+          <span v-show="index < getSaves.length - 1"> , </span>
         </span>
       </p>
       <p v-if="monster.skills">
-        <b class="pad-r-sm">Skills</b>
+        <b class="pr-1">Skills</b>
         <span
           v-for="(skill, key, index) in monster.skills"
           v-show="key !== 'hover'"
@@ -102,7 +98,7 @@
         </span>
       </p>
       <p v-if="monster.damage_vulnerabilities">
-        <b class="pad-r-sm">Damage Vulnerabilities</b>
+        <b class="pr-1">Damage Vulnerabilities</b>
         {{ monster.damage_vulnerabilities }}
       </p>
       <p v-if="monster.damage_resistances">
@@ -114,7 +110,7 @@
       <p v-if="monster.senses"><b>Senses</b> {{ monster.senses }}</p>
       <p v-if="monster.languages"><b>Languages</b> {{ monster.languages }}</p>
       <p v-if="monster.challenge_rating">
-        <b class="pad-r-sm">Challenge</b>
+        <b class="pr-1">Challenge</b>
         <challenge-render :challenge="monster.challenge_rating" />
       </p>
       <hr />

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -2,14 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-  .container {
-    @apply text-slate-900;
-  }
-}
-
 h1 {
-  @apply text-3xl;
+  @apply text-3xl text-blood dark:text-white;
 }
 
 h2 {
@@ -30,4 +24,8 @@ h5 {
 
 h6 {
   @apply text-sm;
+}
+
+blockquote {
+  @apply bg-fog dark:bg-basalt;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,12 +30,12 @@ module.exports = {
         },
 
         // colors from scss variables
-        blood: 'a82315',
+        blood: '#a82315',
         mana: '#166c9c',
         fog: '#f4f4f4',
         smoke: '#d4d4d4',
         granite: '#888',
-        // gray: '#767676', // this conflicts with the existing tailwind class
+        // gray: '#767676', // this conflicts with an existing tailwind class
         basalt: '#333',
         darkness: '#111',
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,7 @@ module.exports = {
     extend: {
       colors: {
         red: {
-          DEFAULT: '#E74C3C',
+          DEFAULT: '#E74C3C', // scss var $color-fireball
           50: '#FBE2DF',
           100: '#F9D1CD',
           200: '#F4B0A9',
@@ -28,7 +28,18 @@ module.exports = {
           900: '#3B0C07',
           950: '#220704',
         },
+
+        // colors from scss variables
+        blood: 'a82315',
+        mana: '#166c9c',
+        fog: '#f4f4f4',
+        smoke: '#d4d4d4',
+        granite: '#888',
+        // gray: '#767676', // this conflicts with the existing tailwind class
+        basalt: '#333',
+        darkness: '#111',
       },
+
       //adds z-index from 1 to 100
       zIndex: zIndex,
     },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,7 @@ module.exports = {
     './components/*.vue',
     './components/**/*.vue',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
This PR closes #108 by adding a dark mode toggle to the website. This feature leverages Tailwind's `dark:` pseudo-class. Most of the work put into this PR was refactoring existing SCSS into Tailwind utility classes so that their colors could be easily changed when attaching to `"dark"` class to the document root.

<img width="1332" alt="Screenshot 2023-07-09 at 20 08 25" src="https://github.com/open5e/open5e/assets/47755775/9c45d4d7-e540-4a98-b441-4f47cfaf89cb">
<img width="1333" alt="Screenshot 2023-07-09 at 20 08 34" src="https://github.com/open5e/open5e/assets/47755775/1d860724-3dbb-4fb4-bcd7-5e9130b992c7">

There is still quite a lot of SCSS that ought to be refactored, in particular the styling that handles screen size break points and responsive design, but that is outside of the scope of this fix. As such some weirdness remains with the positioning of the theme switcher icon on small screens (see below), as I couldn't find a clean way of moving it into the top-right corner of the screen (into the mobile header) without touching those styles. 

<img width="450" alt="Screenshot 2023-07-09 at 20 16 31" src="https://github.com/open5e/open5e/assets/47755775/d76c0c7d-0126-422c-a785-3734219f91ac">