### PR TITLE
Use correct cr filter in api-docs

### DIFF
--- a/pages/api-docs/index.vue
+++ b/pages/api-docs/index.vue
@@ -32,8 +32,8 @@
     <p>
       For example, monsters can be filtered by CR. For example:
       <code
-        ><a href="https://api.open5e.com/monsters/?challenge_rating=3"
-          >api.open5e.com/monsters/?challenge_rating=3</a
+        ><a href="https://api.open5e.com/monsters/?cr=3"
+          >api.open5e.com/monsters/?cr=3</a
         ></code
       >
       will return all monsters with a challenge rating of 3.


### PR DESCRIPTION
The text field `challenge_rating` isn't filterable so the link in the docs doesn't work, switching this to the numeric field `cr`