### PR TITLE
Cross-linking component (#277)

### DIFF
--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -68,17 +68,37 @@ const paramsByType = {
     endpoint: 'backgrounds',
     queryParams: '?fields=name,document__title',
   },
+  characters: {
+    subroute: 'characters',
+    endpoint: 'sections',
+    queryParams: '?fields=name,parent,document__title',
+  },
   class: {
     endpoint: 'classes',
-    queryParams: '',
+    queryParams: '?fields=name,document__title',
+  },
+  combat: {
+    subroute: 'combat',
+    endpoint: 'sections',
+    queryParams: '?fields=name,parent,document__title',
   },
   condition: {
     endpoint: 'conditions',
     queryParams: '?fields=name,desc',
   },
+  equipment: {
+    subroute: 'equipment',
+    endpoint: 'sections',
+    queryParams: '?fields=name,parent,document__title',
+  },
   feat: {
     endpoint: 'feats',
     queryParams: '?fields=name,document__title',
+  },
+  gameplaymechanic: {
+    subroute: 'gameplay-mechanics',
+    endpoint: 'sections',
+    queryParams: '?fields=name,parent,document__title',
   },
   magicitem: {
     subroute: 'magic-items',
@@ -97,9 +117,10 @@ const paramsByType = {
     endpoint: 'races',
     queryParams: '?fields=name,document__title',
   },
-  rule: {
+  running: {
+    subroute: 'running',
     endpoint: 'sections',
-    queryParams: '?fields=name,document__title',
+    queryParams: '?fields=name,parent,document__title',
   },
   spell: {
     endpoint: 'spells',

--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -1,12 +1,16 @@
+<!--
+  This component is global so that the markdown parser can see it and parse the
+  cross-link tags as components. There might be a better way to handle this
+-->
 <template>
   <nuxt-link
-    v-if="acceptibleTypes.includes(type)"
+    v-if="acceptibleTypes.includes(category)"
     :to="url"
     class="group relative"
     @mouseover="loadData"
   >
     {{ title }}
-    <link-preview v-if="content" :content="content" :category="type" />
+    <link-preview v-if="content" :content="content" :category="category" />
   </nuxt-link>
 
   <!-- If link markdown is invalid, render a span instead -->
@@ -28,16 +32,16 @@ export default {
       loading: false,
       content: undefined,
       acceptibleTypes: Object.keys(paramsByType),
-      type: this.resourceType.split('-').join(''), // rmv dashes from prop
+      category: this.resourceType.split('-').join(''), // rmv dashes from prop
     };
   },
   computed: {
     url() {
-      const { subroute, endpoint } = paramsByType[this.type];
+      const { subroute, endpoint } = paramsByType[this.category];
       if (!endpoint) {
         return '/';
       }
-      // link subroute might be different to its API endpoint
+      // the url subroute might be different to its API endpoint
       return `/${subroute ?? endpoint}/${this.slug}`;
     },
   },
@@ -48,7 +52,7 @@ export default {
         return;
       }
       this.loading = true;
-      const { endpoint, queryParams } = paramsByType[this.type];
+      const { endpoint, queryParams } = paramsByType[this.category];
       const apiURL = this.$nuxt.$config.public.apiUrl;
       const res = await axios.get(
         `${apiURL}/${endpoint}/${this.slug}/${queryParams}`
@@ -58,7 +62,7 @@ export default {
   },
 };
 
-// used to map the type of resource passed to the component to details about each api route
+// Maps tag names from markdown to data required to show links/previews
 const paramsByType = {
   armor: {
     endpoint: 'armor',

--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -1,47 +1,21 @@
 <template>
-  <nuxt-link :to="url" class="group relative" @mouseover="fetchOnMouseOver">
+  <nuxt-link
+    v-if="acceptibleTypes.includes(resourceType)"
+    :to="url"
+    class="group relative"
+    @mouseover="fetchOnMouseOver"
+  >
     {{ title }}
-    <article
+    <link-preview
       v-if="content"
-      class="absolute top--1 hidden h-max bg-slate-100 px-4 py-3 text-black shadow-md dark:bg-basalt dark:text-white md:group-hover:block"
-    >
-      <div v-if="resourceType === 'spell'">
-        <p
-          class="group m-0 mb-1 flex justify-between gap-2 border-b-2 border-blood pb-1 align-middle"
-        >
-          <span
-            class="font-serif text-lg font-bold tracking-wide text-blood dark:text-white"
-          >
-            {{ title }}
-          </span>
-
-          <span
-            class="block whitespace-nowrap before:mr-2 before:font-bold before:content-['|']"
-          >
-            {{ content.level }} {{ content.school }} Spell
-          </span>
-        </p>
-
-        <div>
-          <p
-            v-for="item in [
-              { title: 'Casting Time', body: content.casting_time },
-              { title: 'Duration', body: content.duration },
-              { title: 'Range', body: content.range },
-              { title: 'Components', body: content.components },
-            ]"
-            :key="item.title"
-            class="my-0 py-0"
-          >
-            <span class="font-bold after:mr-1 after:content-[':']">
-              {{ item.title }}
-            </span>
-            <span>{{ item.body }}</span>
-          </p>
-        </div>
-      </div>
-    </article>
+      :title="title"
+      :type="resourceType"
+      :content="content"
+    />
   </nuxt-link>
+
+  <!-- If link markdown is invalid, render a span instead -->
+  <span v-else class="italic">{{ title }}</span>
 </template>
 
 <script>
@@ -50,26 +24,36 @@ export default {
   props: {
     title: { type: String, default: '' },
     slug: { type: String, default: '' },
-    resourceType: { type: String, default: undefined },
+    resourceType: { type: String, default: '' },
   },
+
   data() {
     return {
-      url: `/${paramsByType[this.resourceType].endpoint}/${this.slug}`,
       loading: false,
       content: undefined,
+      acceptibleTypes: Object.keys(paramsByType),
     };
+  },
+  computed: {
+    url() {
+      const { endpoint } = paramsByType[this.resourceType];
+      if (!endpoint) {
+        return '/';
+      }
+      return `/${paramsByType[this.resourceType].endpoint}/${this.slug}`;
+    },
   },
   methods: {
     fetchOnMouseOver: async function () {
-      // only fetch on initial hover
+      // guard clause so that data is only fetched on initial hover
       if (this.loading || this.content) {
         return;
       }
       this.loading = true;
-      const { endpoint, params } = paramsByType[this.resourceType];
+      const { endpoint, queryParams } = paramsByType[this.resourceType];
       const apiURL = this.$nuxt.$config.public.apiUrl;
       const res = await axios.get(
-        `${apiURL}/${endpoint}/${this.slug}/${params}`
+        `${apiURL}/${endpoint}/${this.slug}/${queryParams}`
       );
       this.content = res.data;
     },
@@ -80,47 +64,48 @@ export default {
 const paramsByType = {
   armor: {
     endpoint: 'armor',
-    params: '?fields=name,category',
+    queryParams: '?fields=name,category',
   },
   background: {
     endpoint: 'backgrounds',
-    params: '?fields=name,document__title',
+    queryParams: '?fields=name,document__title',
   },
   class: {
     endpoint: 'classes',
-    params: '?fields=name',
+    queryParams: '',
   },
   condition: {
     endpoint: 'conditions',
-    params: '?fields=name,desc',
+    queryParams: '?fields=name,desc',
   },
   feat: {
     endpoint: 'feats',
-    params: '?fields=name,document__title',
+    queryParams: '?fields=name,document__title',
   },
   magicitem: {
     endpoint: 'magicitem',
-    params: '?fields=name,type,rarity,requires_attunement',
+    queryParams: '?fields=name,type,rarity,requires_attunement,document__title',
   },
   monster: {
     endpoint: 'monsters',
-    params: '?fields=name,size,type,challenge_rating,document__title',
+    queryParams: '?fields=name,size,type,challenge_rating,document__title',
   },
-  planes: {
+  plane: {
     endpoint: 'planes',
-    params: '?fields=name',
+    queryParams: '?fields=name',
   },
-  section: {
-    endpoint: 'sections',
-    params: '?fields=name,parent,document__title',
+  race: {
+    endpoint: 'races',
+    queryParams: '?fields=name,document__title',
   },
   spell: {
     endpoint: 'spells',
-    params: '?fields=name,level,school,casting_time,duration,range,components',
+    queryParams:
+      '?fields=name,level,school,casting_time,duration,range,components,document__title',
   },
   weapon: {
     endpoint: 'weapons',
-    params: '?field=name,category',
+    queryParams: '?field=name,category',
   },
 };
 </script>

--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -3,17 +3,43 @@
     {{ title }}
     <article
       v-if="content"
-      class="group absolute top--1 hidden h-32 w-64 bg-slate-100 px-3 text-black group-hover:block dark:bg-basalt dark:text-white"
+      class="absolute top--1 hidden h-max bg-slate-100 px-4 py-3 text-black shadow-md dark:bg-basalt dark:text-white md:group-hover:block"
     >
-      <p class="group flex justify-center gap-2 uppercase">
-        <span class="text-lg font-bold">{{ title }}</span>
-      </p>
       <div v-if="resourceType === 'spell'">
-        <p class="text-red">{{ content.level }} {{ content.school }} Spell</p>
+        <p
+          class="group m-0 mb-1 flex justify-between gap-2 border-b-2 border-blood pb-1 align-middle"
+        >
+          <span
+            class="font-serif text-lg font-bold tracking-wide text-blood dark:text-white"
+          >
+            {{ title }}
+          </span>
+
+          <span
+            class="block whitespace-nowrap before:mr-2 before:font-bold before:content-['|']"
+          >
+            {{ content.level }} {{ content.school }} Spell
+          </span>
+        </p>
+
+        <div>
+          <p
+            v-for="item in [
+              { title: 'Casting Time', body: content.casting_time },
+              { title: 'Duration', body: content.duration },
+              { title: 'Range', body: content.range },
+              { title: 'Components', body: content.components },
+            ]"
+            :key="item.title"
+            class="my-0 py-0"
+          >
+            <span class="font-bold after:mr-1 after:content-[':']">
+              {{ item.title }}
+            </span>
+            <span>{{ item.body }}</span>
+          </p>
+        </div>
       </div>
-      <p class="justify-self-center pt-0 text-sm text-basalt dark:text-smoke">
-        {{ `https://open5e.com${url}` }}
-      </p>
     </article>
   </nuxt-link>
 </template>
@@ -50,7 +76,8 @@ export default {
       this.loading = true;
       const apiURL = this.$nuxt.$config.public.apiUrl;
       const endpoint = `${this.resourceType}s/${this.title.toLowerCase()}`;
-      const params = '?fields=level,school';
+      const params =
+        '?fields=level,school,casting_time,duration,range,components';
       const res = await axios.get(`${apiURL}/${endpoint}/${params}`);
       this.content = res.data;
     },

--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -46,41 +46,81 @@
 
 <script>
 import axios from 'axios';
-
 export default {
   props: {
-    title: {
-      type: String,
-      default: '',
-    },
-    url: {
-      type: String,
-      default: '',
-    },
-    resourceType: {
-      type: String,
-      default: undefined,
-    },
+    title: { type: String, default: '' },
+    slug: { type: String, default: '' },
+    resourceType: { type: String, default: undefined },
   },
   data() {
     return {
+      url: `/${paramsByType[this.resourceType].endpoint}/${this.slug}`,
       loading: false,
       content: undefined,
     };
   },
   methods: {
     fetchOnMouseOver: async function () {
+      // only fetch on initial hover
       if (this.loading || this.content) {
         return;
       }
       this.loading = true;
+      const { endpoint, params } = paramsByType[this.resourceType];
       const apiURL = this.$nuxt.$config.public.apiUrl;
-      const endpoint = `${this.resourceType}s/${this.title.toLowerCase()}`;
-      const params =
-        '?fields=level,school,casting_time,duration,range,components';
-      const res = await axios.get(`${apiURL}/${endpoint}/${params}`);
+      const res = await axios.get(
+        `${apiURL}/${endpoint}/${this.slug}/${params}`
+      );
       this.content = res.data;
     },
+  },
+};
+
+// used to map the type of resource passed to the component to details about each api route
+const paramsByType = {
+  armor: {
+    endpoint: 'armor',
+    params: '?fields=name,category',
+  },
+  background: {
+    endpoint: 'backgrounds',
+    params: '?fields=name,document__title',
+  },
+  class: {
+    endpoint: 'classes',
+    params: '?fields=name',
+  },
+  condition: {
+    endpoint: 'conditions',
+    params: '?fields=name,desc',
+  },
+  feat: {
+    endpoint: 'feats',
+    params: '?fields=name,document__title',
+  },
+  magicitem: {
+    endpoint: 'magicitem',
+    params: '?fields=name,type,rarity,requires_attunement',
+  },
+  monster: {
+    endpoint: 'monsters',
+    params: '?fields=name,size,type,challenge_rating,document__title',
+  },
+  planes: {
+    endpoint: 'planes',
+    params: '?fields=name',
+  },
+  section: {
+    endpoint: 'sections',
+    params: '?fields=name,parent,document__title',
+  },
+  spell: {
+    endpoint: 'spells',
+    params: '?fields=name,level,school,casting_time,duration,range,components',
+  },
+  weapon: {
+    endpoint: 'weapons',
+    params: '?field=name,category',
   },
 };
 </script>

--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -1,18 +1,59 @@
 <template>
-  <nuxt-link :to="url">
-    <slot />
+  <nuxt-link :to="url" class="group relative" @mouseover="fetchOnMouseOver">
+    {{ title }}
+    <article
+      v-if="content"
+      class="group absolute top--1 hidden h-32 w-64 bg-slate-100 px-3 text-black group-hover:block dark:bg-basalt dark:text-white"
+    >
+      <p class="group flex justify-center gap-2 uppercase">
+        <span class="text-lg font-bold">{{ title }}</span>
+      </p>
+      <div v-if="resourceType === 'spell'">
+        <p class="text-red">{{ content.level }} {{ content.school }} Spell</p>
+      </div>
+      <p class="justify-self-center pt-0 text-sm text-basalt dark:text-smoke">
+        {{ `https://open5e.com${url}` }}
+      </p>
+    </article>
   </nuxt-link>
 </template>
 
 <script>
+import axios from 'axios';
+
 export default {
   props: {
+    title: {
+      type: String,
+      default: '',
+    },
     url: {
       type: String,
       default: '',
     },
+    resourceType: {
+      type: String,
+      default: undefined,
+    },
+  },
+  data() {
+    return {
+      loading: false,
+      content: undefined,
+    };
+  },
+  methods: {
+    fetchOnMouseOver: async function () {
+      if (this.loading || this.content) {
+        return;
+      }
+      this.loading = true;
+      const apiURL = this.$nuxt.$config.public.apiUrl;
+      const endpoint = `${this.resourceType}s/${this.title.toLowerCase()}`;
+      const params = '?fields=level,school';
+      const res = await axios.get(`${apiURL}/${endpoint}/${params}`);
+      this.content = res.data;
+    },
   },
 };
 </script>
-
-<style></style>

--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -1,0 +1,18 @@
+<template>
+  <nuxt-link :to="url">
+    <slot />
+  </nuxt-link>
+</template>
+
+<script>
+export default {
+  props: {
+    url: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>
+
+<style></style>

--- a/components/LinkPreview.vue
+++ b/components/LinkPreview.vue
@@ -1,0 +1,72 @@
+<template>
+  <article
+    class="absolute top--1 z-10 hidden h-max bg-slate-100 px-4 py-3 text-black shadow-md dark:bg-basalt dark:text-white md:group-hover:block"
+  >
+    <p class="m-0 whitespace-nowrap border-b-2 border-blood pb-1 align-middle">
+      <span class="font-serif text-lg font-bold text-blood dark:text-white">
+        {{ title }}
+      </span>
+      <span class="before:mx-2 before:font-bold before:content-['|']">
+        {{ subtitle }}
+      </span>
+    </p>
+
+    <p v-for="item in body" :key="item.title" class="m-0 p-0">
+      <span class="font-bold after:mr-1 after:content-[':']">
+        {{ item.title }}
+      </span>
+      <span>{{ item.data }} </span>
+    </p>
+
+    <p v-if="content.document__title" class="whitespace-nowrap text-sm italic">
+      Source: {{ content.document__title }}
+    </p>
+  </article>
+</template>
+
+<script>
+export default {
+  props: {
+    title: { type: String, default: '' },
+    type: { type: String, default: '' },
+    // eslint-disable-next-line vue/require-prop-types
+    content: { default: [] },
+  },
+  computed: {
+    // generate an appropriate subtitle for the resource type
+    subtitle() {
+      const data = this.content;
+      switch (this.type) {
+        case 'spell':
+          return `${data.level} ${data.school} Spell`;
+        case 'monster':
+          return `${data.size} ${data.type} CR ${data.challenge_rating}`;
+        default:
+          return this.type.charAt(0).toUpperCase() + this.type.slice(1);
+      }
+    },
+    body() {
+      const data = this.content;
+      switch (this.type) {
+        case 'spell':
+          return [
+            { title: 'Casting Time', data: data.casting_time },
+            { title: 'Duration', data: data.duration },
+            { title: 'Range', data: data.range },
+            { title: 'Components', data: data.components },
+          ];
+        case 'magicitem':
+          return [
+            `${data.type}, ${data.rarity} ${
+              data.requires_attunement ?? '{requires attunement}'
+            }`,
+          ];
+        default:
+          return [];
+      }
+    },
+  },
+};
+</script>
+
+<style></style>

--- a/components/LinkPreview.vue
+++ b/components/LinkPreview.vue
@@ -13,7 +13,7 @@
     </p>
 
     <!-- Generate card body from data -->
-    <p v-for="item in body" :key="item.title" class="m-0 p-0">
+    <p v-for="item in body" :key="item.title" class="m-0 p-0 text-sm">
       <span v-if="item.title" class="font-bold after:mr-1 after:content-[':']">
         {{ item.title }}
       </span>
@@ -37,35 +37,54 @@ export default {
   computed: {
     // generate an appropriate subtitle for each resource type
     subtitle() {
+      console.log(this.category);
       const data = this.content;
       switch (this.category) {
-        case 'spell':
+        case 'spells':
           return `${data.level} ${data.school} Spell`;
-        case 'monster':
-          return `${data.size} ${data.type} CR ${data.challenge_rating}`;
-        case 'magicitem':
-          return `${data.type}, ${data.rarity} 
-            ${data.requires_attunement ?? '(requires attunement)'}
-          `;
+        case 'monsters':
+          return 'Monster';
+        case 'magicitems':
+          return 'Magic Item';
+        case 'conditions':
+          return 'Condition';
+        case 'feats':
+          return 'Feat';
+        case 'sections':
         case 'characters':
         case 'combat':
         case 'equipment':
-        case 'gameplaymechanic':
+        case 'gameplay-mechanics':
         case 'running':
-          return data.parent.charAt(0).toUpperCase() + data.parent.slice(1);
+          return data.parent;
         default:
           return this.category.charAt(0).toUpperCase() + this.category.slice(1);
       }
     },
+
     body() {
       const data = this.content;
       switch (this.category) {
-        case 'spell':
+        case 'conditions':
+          return [{ data: data.desc }];
+        case 'spells':
           return [
             { title: 'Casting Time', data: data.casting_time },
             { title: 'Duration', data: data.duration },
             { title: 'Range', data: data.range },
             { title: 'Components', data: data.components },
+          ];
+        case 'magicitems':
+          return [
+            {
+              data: `${data.type}, ${data.rarity} ${
+                data.requires_attunement && '(requires attunement)'
+              }`,
+            },
+          ];
+        case 'monsters':
+          return [
+            { data: `CR ${data.challenge_rating} ${data.type} (${data.size})` },
           ];
         default:
           return [];

--- a/components/LinkPreview.vue
+++ b/components/LinkPreview.vue
@@ -2,22 +2,25 @@
   <article
     class="absolute top--1 z-10 hidden h-max bg-slate-100 px-4 py-3 text-black shadow-md dark:bg-basalt dark:text-white md:group-hover:block"
   >
+    <!-- Generate card title from data -->
     <p class="m-0 whitespace-nowrap border-b-2 border-blood pb-1 align-middle">
       <span class="font-serif text-lg font-bold text-blood dark:text-white">
-        {{ title }}
+        {{ content.name }}
       </span>
       <span class="before:mx-2 before:font-bold before:content-['|']">
         {{ subtitle }}
       </span>
     </p>
 
+    <!-- Generate card body from data -->
     <p v-for="item in body" :key="item.title" class="m-0 p-0">
-      <span class="font-bold after:mr-1 after:content-[':']">
+      <span v-if="item.title" class="font-bold after:mr-1 after:content-[':']">
         {{ item.title }}
       </span>
       <span>{{ item.data }} </span>
     </p>
 
+    <!-- Card footer -->
     <p v-if="content.document__title" class="whitespace-nowrap text-sm italic">
       Source: {{ content.document__title }}
     </p>
@@ -27,39 +30,36 @@
 <script>
 export default {
   props: {
-    title: { type: String, default: '' },
-    type: { type: String, default: '' },
+    category: { type: String, default: '' },
     // eslint-disable-next-line vue/require-prop-types
     content: { default: [] },
   },
   computed: {
-    // generate an appropriate subtitle for the resource type
+    // generate an appropriate subtitle for each resource type
     subtitle() {
       const data = this.content;
-      switch (this.type) {
+      switch (this.category) {
         case 'spell':
           return `${data.level} ${data.school} Spell`;
         case 'monster':
           return `${data.size} ${data.type} CR ${data.challenge_rating}`;
+        case 'magicitem':
+          return `${data.type}, ${data.rarity} 
+            ${data.requires_attunement ?? '(requires attunement)'}
+          `;
         default:
-          return this.type.charAt(0).toUpperCase() + this.type.slice(1);
+          return this.category.charAt(0).toUpperCase() + this.category.slice(1);
       }
     },
     body() {
       const data = this.content;
-      switch (this.type) {
+      switch (this.category) {
         case 'spell':
           return [
             { title: 'Casting Time', data: data.casting_time },
             { title: 'Duration', data: data.duration },
             { title: 'Range', data: data.range },
             { title: 'Components', data: data.components },
-          ];
-        case 'magicitem':
-          return [
-            `${data.type}, ${data.rarity} ${
-              data.requires_attunement ?? '{requires attunement}'
-            }`,
           ];
         default:
           return [];

--- a/components/LinkPreview.vue
+++ b/components/LinkPreview.vue
@@ -47,6 +47,12 @@ export default {
           return `${data.type}, ${data.rarity} 
             ${data.requires_attunement ?? '(requires attunement)'}
           `;
+        case 'characters':
+        case 'combat':
+        case 'equipment':
+        case 'gameplaymechanic':
+        case 'running':
+          return data.parent.charAt(0).toUpperCase() + data.parent.slice(1);
         default:
           return this.category.charAt(0).toUpperCase() + this.category.slice(1);
       }

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -4,6 +4,7 @@
     :vue-template="true"
     :options="{ tables: true, headerLevelStart: headerLevel }"
     :markdown="mdText"
+    :extensions="insertCrossLinks"
   />
 </template>
 
@@ -47,6 +48,15 @@ export default {
         return this.text;
       }
     },
+
+    // Showdown extension for inserting cross-links into markdown
+    insertCrossLinks: () => [
+      {
+        type: 'lang',
+        regex: /<(spell|monster):(\w+)>(\w+)<\/(spell|monster)>/g,
+        replace: '<a href="/$1s/$2">$3</a>',
+      },
+    ],
   },
   mounted() {
     if (this.src) {

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -51,7 +51,13 @@ export default {
         return this.text;
       }
     },
-    // Showdown extension for inserting cross-links into markdown
+    /* Showdown extension for inserting cross-links into markdown w/ regex
+     * Example inputs & outputs
+     * Input 1: <spell:fireball>Fireball</spell>
+     * Output 1: <cross-link resourceType=”spell” slug=”fireball” title=”Fireball” version=""/>
+     * Input 2: <magic-item:ioun-stone v2>Ioun Stone</magic-item>
+     * Output 2: <cross-link resourceType=”magic-item” slug=”ioun-stone” title=”Ioun Stone” version="2"/>
+     */
     insertCrossLinks: () => [
       {
         type: 'output',

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -21,72 +21,47 @@ export default {
   name: 'MdViewer',
   components: { VueShowdown },
   props: {
-    src: {
-      type: String || undefined,
-      default: undefined,
-    },
-    toc: {
-      type: Boolean,
-      default: true,
-    },
-    text: {
-      type: String,
-      default: 'loading...',
-    },
-    headerLevel: {
-      type: Number,
-      default: 1,
-    },
+    src: { type: String || undefined, default: undefined },
+    toc: { type: Boolean, default: true },
+    text: { type: String, default: 'loading...' },
+    headerLevel: { type: Number, default: 1 },
   },
   data() {
-    return {
-      sourceText: '',
-    };
+    return { sourceText: '' };
   },
   computed: {
     mdText: function () {
-      if (this.sourceText) {
-        return this.sourceText;
-      } else {
-        return this.text;
-      }
+      return this.sourceText ? this.sourceText : this.text;
     },
-    /* Showdown extension for inserting cross-links into markdown w/ regex
-     * Example inputs & outputs
-     * Input 1: <spell:fireball>Fireball</spell>
-     * Output 1: <cross-link resourceType=”spell” slug=”fireball” title=”Fireball” version=""/>
-     * Input 2: <magic-item:ioun-stone v2>Ioun Stone</magic-item>
-     * Output 2: <cross-link resourceType=”magic-item” slug=”ioun-stone” title=”Ioun Stone” version="2"/>
-     */
+
     insertCrossLinks: () => [
       {
         type: 'output',
-        regex: /<([a-z-]+):([^ >]+)(?:\s+v(\d+))?>\s*([^<]+)\s*<\/\1>/g,
-        replace:
-          '<cross-link resourceType="$1" slug="$2" title="$4" version="$3"/>',
+        regex: /<open5e-link src=([^>]+)>([^<]+)<\/open5e-link>/g,
+        replace: '<cross-link src="$1">$2</cross-link>',
       },
     ],
   },
   mounted() {
-    if (this.src) {
-      axios.get(this.src).then((response) => {
-        this.sourceText = response.data;
-        this.scrollToRoute();
-      });
+    if (!this.src) {
+      return;
     }
+    axios.get(this.src).then((response) => {
+      this.sourceText = response.data;
+      this.scrollToRoute();
+    });
   },
   methods: {
     scrollToRoute: function () {
-      if (this.$route.hash) {
-        this.$nextTick(() => {
-          const hash = this.$route.hash;
-          const container = this.$el.querySelector(hash);
-          container.scrollIntoView({ behavior: 'smooth' });
-        });
+      if (!this.$route.hash) {
+        return;
       }
+      this.$nextTick(() => {
+        const hash = this.$route.hash;
+        const container = this.$el.querySelector(hash);
+        container.scrollIntoView({ behavior: 'smooth' });
+      });
     },
   },
 };
 </script>
-
-<style lang="scss"></style>

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -55,8 +55,8 @@ export default {
     insertCrossLinks: () => [
       {
         type: 'output',
-        regex: /<(spell|monster):(\w+)>(\w+)<\/(spell|monster)>/g,
-        replace: '<cross-link resourceType="$1" url="/$1s/$2" title="$3" />',
+        regex: /<([^:]+):([^>]+)>(.*?)<\/\1>/g,
+        replace: '<cross-link resourceType="$1" slug="$2" title="$3" />',
       },
     ],
   },

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -55,8 +55,9 @@ export default {
     insertCrossLinks: () => [
       {
         type: 'output',
-        regex: /<([^:]+):([^>]+)>(.*?)<\/\1>/g,
-        replace: '<cross-link resourceType="$1" slug="$2" title="$3" />',
+        regex: /<([a-z-]+):([^ >]+)(?:\s+v(\d+))?>\s*([^<]+)\s*<\/\1>/g,
+        replace:
+          '<cross-link resourceType="$1" slug="$2" title="$4" version="$3"/>',
       },
     ],
   },

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -1,22 +1,25 @@
 <template>
-  <VueShowdown
-    ref="mdwrapper"
-    :vue-template="true"
-    :options="{ tables: true, headerLevelStart: headerLevel }"
-    :markdown="mdText"
-    :extensions="insertCrossLinks"
-  />
+  <div>
+    <VueShowdown
+      ref="mdwrapper"
+      :vue-template="true"
+      :options="{
+        tables: true,
+        headerLevelStart: headerLevel,
+        vueTemplate: true,
+      }"
+      :markdown="mdText"
+      :extensions="insertCrossLinks"
+    />
+  </div>
 </template>
 
 <script>
 import axios from 'axios';
 import { VueShowdown } from 'vue-showdown';
-
 export default {
   name: 'MdViewer',
-  components: {
-    VueShowdown: VueShowdown,
-  },
+  components: { VueShowdown },
   props: {
     src: {
       type: String || undefined,
@@ -48,13 +51,12 @@ export default {
         return this.text;
       }
     },
-
     // Showdown extension for inserting cross-links into markdown
     insertCrossLinks: () => [
       {
-        type: 'lang',
+        type: 'output',
         regex: /<(spell|monster):(\w+)>(\w+)<\/(spell|monster)>/g,
-        replace: '<a href="/$1s/$2">$3</a>',
+        replace: '<cross-link href="/$1s/$2">$3</cross-link>',
       },
     ],
   },

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -56,7 +56,7 @@ export default {
       {
         type: 'output',
         regex: /<(spell|monster):(\w+)>(\w+)<\/(spell|monster)>/g,
-        replace: '<cross-link href="/$1s/$2">$3</cross-link>',
+        replace: '<cross-link resourceType="$1" url="/$1s/$2" title="$3" />',
       },
     ],
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,10 @@ module.exports = {
   ],
   darkMode: 'class',
   theme: {
+    fontFamily: {
+      sans: ['"Source Sans Pro"', 'sans-serif'],
+      serif: ['"Lora"', 'serif'],
+    },
     extend: {
       colors: {
         red: {


### PR DESCRIPTION
This PR closes #277 by adding a cross-links. These are links to pages on the website that can be added into markdown from the API that get parsed into links on the frontend (with a preview on hover). While the main use case for this feature is to add links to spells referenced in monster stat-blocks and magic item descriptions, you should be able to link to any article on the site. 

<img width="751" alt="Screenshot 2023-08-22 at 23 02 56" src="https://github.com/open5e/open5e/assets/47755775/95d1cd6c-dcba-4cfc-b630-3dad76a43141">

<img width="739" alt="Screenshot 2023-08-22 at 23 03 04" src="https://github.com/open5e/open5e/assets/47755775/feecb200-7cbc-4b5c-9213-a0f5684a2305">

### Usage

You can use the following syntax to insert a link into markdown:

```<[category]:[slug]>[title]</[category]>```

The markdown parsed will see this, and replace it with:
```<cross-link resourceType="[category]" slug="[slug]" title="[title]" />```

**Category**  determines which API endpoint to query (if you are querying the /sections endpoint, then set category to the artical's *parent* instead). **Slug** is the slug/UID of the artical you want to link to. **Title** controls the display text of the link.

For example:
```<spell:fireball>Fireball</spell>```
```<magic-item:neckace-of-fireballs>Necklace of Fireballs</magic-item>```
```<equipment:adventuring-gear>Adventuring Gear</equipment>```

### API Versions

While nothing on the frontend is currently set up to work with the new version of the open5e API, I have included the ability to add an optional **version** parameter to the tag. Just in case.

Input: `<spell:fireball v2>Fireball</spell>`
Output: `<cross-link resourceType="spell" slug="fireball" title="Fireball" version="2" />`