### PR TITLE
Bugfix: query params in breadcrumbs

### DIFF
--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -45,8 +45,12 @@ export default {
           // rebuild link urls segment by segment
           url += `/${segment}`;
 
-          // seperate query params
-          const [title, searchParam] = segment.split('?text=');
+          // seperate segment title & query params
+          const [title, queryParams] = segment.split('?');
+          // extract & format the search params if on the /search route
+          const searchParam =
+            title === 'search' &&
+            queryParams.split('text=')[1].split('+').join(' ');
 
           return {
             url,

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -30,7 +30,6 @@ export default {
   computed: {
     crumbs() {
       const params = this.$route.fullPath.split('/');
-
       let path = '';
 
       const crumbs = params
@@ -42,16 +41,20 @@ export default {
 
           path = `${path}/${param}`;
 
-          // format breadcrumb title from path
-          const title = param
-            .split('-')
-            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' ');
-          return { title: title, url: path };
+          // seperate title and query params
+          const [title, queryParam] = param.split('?text=');
+
+          return {
+            url: path,
+            title: title
+              .split('-') // format crumb title
+              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+              .join(' '),
+          };
         })
         .filter((element) => element); // remove null crumbs
 
-      // prepend Home route
+      // prepend Home route to list of crumbs
       return [{ title: 'Home', url: '/' }, ...crumbs];
     },
   },

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -19,6 +19,9 @@
             class="mr-1"
           />
           <span>{{ crumb.title }}</span>
+          <span v-if="crumb.subtitle" class="ml-2 font-thin text-granite">
+            ({{ crumb.subtitle }})
+          </span>
         </nuxt-link>
       </li>
     </ol>
@@ -29,33 +32,35 @@
 export default {
   computed: {
     crumbs() {
-      const params = this.$route.fullPath.split('/');
-      let path = '';
-
-      const crumbs = params
-        .map((param) => {
+      // iterate over segments of current path to create breadcrumbs
+      let url = '';
+      const breadcrumbs = this.$route.fullPath
+        .split('/')
+        .map((segment) => {
           // ignore initial & trailing slashes
-          if (param === '' || param === '/') {
+          if (segment === '' || segment === '/') {
             return;
           }
 
-          path = `${path}/${param}`;
+          // rebuild link urls segment by segment
+          url += `/${segment}`;
 
-          // seperate title and query params
-          const [title, queryParam] = param.split('?text=');
+          // seperate query params
+          const [title, searchParam] = segment.split('?text=');
 
           return {
-            url: path,
-            title: title
-              .split('-') // format crumb title
+            url,
+            title: title // format crumb title
+              .split('-')
               .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
               .join(' '),
+            subtitle: searchParam,
           };
         })
-        .filter((element) => element); // remove null crumbs
+        .filter((breadcrumb) => breadcrumb); // filter null crumbs
 
       // prepend Home route to list of crumbs
-      return [{ title: 'Home', url: '/' }, ...crumbs];
+      return [{ title: 'Home', url: '/' }, ...breadcrumbs];
     },
   },
 };


### PR DESCRIPTION
This PR fixes a visual bug with the Breadcrumb links where any query parameters in the current URL would be displayed as part of the link title. This error is especially noticable when using the search bar.

<img width="480" alt="screenshot" src="https://github.com/open5e/open5e/assets/47755775/df2d5cac-d7f3-46bd-af13-91c15e6db405">

### Recreation

1. Checkout the `staging` branch
2. Using the search bar, search for anything

### The Fix

Filtering out the query parameters from the routes that the BreadcrumbLinks component uses to generate the links. Then checking if we are on the `/search` route and adding the search param back in the breadcrumb with appropriate formatting

<img width="480" alt="screenshot" src="https://github.com/open5e/open5e/assets/47755775/4a38c24b-f302-4f19-84d5-24117ba6fc19">
