### PR TITLE
Bugfix: improved redirects and fixing the 404 page

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -1,17 +1,14 @@
 <template>
   <div class="container">
     <h1>Critical Failure!</h1>
-    <h2>Error {{ error.statusCode }}</h2>
-    <p>
-      <em>{{ error.message }}.</em>
-    </p>
+    <h2>Error {{ error?.statusCode }}</h2>
+    <p class="font-italics">{{ error?.message }}</p>
 
-    <br />
+    <button class="font-bold text-red hover:text-blood" @click="handleError">
+      Return to Homepage
+    </button>
 
-    <ul>
-      <li>Return to the <nuxt-link to="/"> Home </nuxt-link> page</li>
-      <li>Try searching for what you need in the site menu</li>
-    </ul>
+    <p>Try searching for what you need in the site menu</p>
 
     <div class="roll-container">
       <svg
@@ -78,10 +75,14 @@
   </div>
 </template>
 
-<script>
-export default {
-  props: ['error'],
-};
+<script setup>
+const props = defineProps({
+  error: {
+    default: undefined,
+    type: Object || undefined,
+  },
+});
+const handleError = () => clearError({ redirect: '/' });
 </script>
 
 <style>
@@ -109,14 +110,5 @@ export default {
   to {
     transform: rotate(360deg);
   }
-}
-
-.in-page-search {
-  border: 2px solid #e74c3c;
-  font-size: 0.8em;
-  margin: 0.8em;
-  max-width: 100%;
-  padding: 0.8em;
-  width: 30em;
 }
 </style>

--- a/middleware/redirects.global.js
+++ b/middleware/redirects.global.js
@@ -52,6 +52,6 @@ export default defineNuxtRouteMiddleware((to) => {
 
   // check whether a /section/ route needs to be replaced with parent from API
   if (path.search('/sections/') > -1) {
-    return navigateTo(replaceSectionsWithParent(path));
+    return navigateTo(replaceSectionsWithParent(path), { redirectCode: 301 });
   }
 });

--- a/pages/backgrounds/[background].vue
+++ b/pages/backgrounds/[background].vue
@@ -43,29 +43,26 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
-import SourceTag from '~/components/SourceTag';
 export default {
-  components: { MdViewer, SourceTag },
   data() {
-    return {
-      title: '',
-      background: null,
-    };
+    return { background: null };
   },
 
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/backgrounds/${
-      this.$route.params.background
-    }`;
-    console.log(this.$route.params.background);
+    const { background } = useRoute().params;
+    const { apiUrl } = useRuntimeConfig().public;
+    const url = `${apiUrl}/backgrounds/${background}/`;
 
     //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.background = response.data;
-    });
+    return axios
+      .get(url)
+      .then((response) => (this.background = response.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>
-
-<style></style>

--- a/pages/characters/[section].vue
+++ b/pages/characters/[section].vue
@@ -1,6 +1,6 @@
 <template>
   <main v-if="section" class="docs-container container">
-    <h1>{{ title }}</h1>
+    <h1>{{ section.title }}</h1>
     <section>
       <md-viewer :text="section.desc" />
     </section>
@@ -10,26 +10,25 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
 export default {
-  components: { MdViewer },
   data() {
-    return {
-      title: '',
-      section: null,
-    };
+    return { section: null };
   },
 
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/sections/${
-      this.$route.params.section
-    }`;
+    const { section } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/sections/${section}/`;
 
     //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.section = response.data;
-      this.title = response.data.name;
-    });
+    return axios
+      .get(url)
+      .then((res) => (this.section = res.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>

--- a/pages/classes/[className]/[subclass].vue
+++ b/pages/classes/[className]/[subclass].vue
@@ -16,28 +16,32 @@
 </template>
 
 <script>
-import MdViewer from '~/components/MdViewer.vue';
-import SourceTag from '~/components/SourceTag.vue';
 import axios from 'axios';
-
 export default {
-  components: { MdViewer, SourceTag },
   data() {
-    return {
-      subclass: null,
-    };
+    return { subclass: null };
   },
-
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/classes/${
-      this.$route.params.className
-    }`;
+    const { className, subclass } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/classes/${className}/`;
+
     //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.subclass = response.data.archetypes.find(
-        (subclass) => subclass.slug === this.$route.params.subclass
-      );
-    });
+    return axios
+      .get(url)
+      .then((response) => {
+        this.subclass = response.data.archetypes.find(
+          (subclass) => subclass.slug === this.$route.params.subclass
+        );
+        if (!this.subclass) {
+          navigateTo(`/classes/${className}`, { statusCode: '404' });
+        }
+      })
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -1,59 +1,59 @@
 <template>
-  <main v-if="classDetails" class="docs-container container">
-    <h1>{{ className }}</h1>
+  <main v-if="classData" class="docs-container container">
+    <h1>{{ classData.name }}</h1>
 
     <section>
       <h2>Class Features</h2>
-      <p>As a {{ className }} you gain the following features.</p>
+      <p>As a {{ classData.name }} you gain the following features.</p>
       <h3>Hit Points</h3>
       <p>
         <span class="font-bold">Hit Dice: </span>
-        {{ classDetails.hit_dice }} per {{ className }} level
+        {{ classData.hit_dice }} per {{ classData.name }} level
       </p>
       <p>
         <span class="font-bold">Hit Points at 1st Level: </span>
-        {{ classDetails.hp_at_1st_level }}
+        {{ classData.hp_at_1st_level }}
       </p>
       <p>
         <span class="font-bold">Hit Points at Higher Levels: </span>
-        {{ classDetails.hp_at_higher_levels }}
+        {{ classData.hp_at_higher_levels }}
       </p>
 
       <h3>Proficiencies</h3>
       <p>
         <span class="font-bold">Armor: </span>
-        {{ classDetails.prof_armor }}
+        {{ classData.prof_armor }}
       </p>
       <p>
         <span class="font-bold">Weapons: </span>
-        {{ classDetails.prof_weapons }}
+        {{ classData.prof_weapons }}
       </p>
       <p>
         <span class="font-bold">Tools: </span>
-        {{ classDetails.prof_tools }}
+        {{ classData.prof_tools }}
       </p>
       <p>
         <span class="font-bold">Saving Throws: </span>
-        {{ classDetails.prof_saving_throws }}
+        {{ classData.prof_saving_throws }}
       </p>
       <p>
         <span class="font-bold">Skills: </span>
-        {{ classDetails.prof_skills }}
+        {{ classData.prof_skills }}
       </p>
 
       <h3>The {{ className }}</h3>
-      <md-viewer :text="classDetails.table" />
+      <md-viewer :text="classData.table" />
     </section>
 
     <section>
       <h2>Class Abilities</h2>
-      <md-viewer :text="classDetails.desc" />
+      <md-viewer :text="classData.desc" />
     </section>
     <section>
-      <h2>{{ classDetails.subtypes_name }}</h2>
-      <ul v-for="archetype in classDetails.archetypes" :key="archetype">
+      <h2>{{ classData.subtypes_name }}</h2>
+      <ul v-for="archetype in classData.archetypes" :key="archetype">
         <li>
-          <nuxt-link :to="`${classDetails.slug}/${archetype.slug}`" tag="a">
+          <nuxt-link :to="`${classData.slug}/${archetype.slug}`" tag="a">
             {{ archetype.name }}
           </nuxt-link>
         </li>
@@ -65,28 +65,25 @@
 </template>
 
 <script>
-import MdViewer from '~/components/MdViewer';
 import axios from 'axios';
 
 export default {
-  components: { MdViewer },
   data() {
-    return {
-      className: '',
-      classDetails: null,
-      url: '',
-    };
+    return { classData: undefined };
   },
-
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/classes/${
-      this.$route.params.className
-    }`;
+    const { className } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/classes/${className}/`;
     //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.classDetails = response.data;
-      this.className = response.data.name;
-    });
+    return axios
+      .get(url)
+      .then((response) => (this.classData = response.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>

--- a/pages/combat/[section].vue
+++ b/pages/combat/[section].vue
@@ -1,37 +1,33 @@
 <template>
   <main v-if="section" class="docs-container container">
-    <h1>{{ title }}</h1>
+    <h1>{{ section.name }}</h1>
     <section>
       <md-viewer :text="section.desc" />
     </section>
   </main>
-  <p v-else>Loading...</p>
 </template>
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
 export default {
-  components: { MdViewer },
   data() {
     return {
-      title: '',
-      section: null,
+      section: undefined,
+      error: undefined,
     };
   },
-
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/sections/${
-      this.$route.params.section
-    }`;
-
-    //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.section = response.data;
-      this.title = response.data.name;
-    });
+    const { section } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/sections/${section}/`;
+    axios
+      .get(url)
+      .then((response) => (this.section = response.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `The route ${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>
-
-<style></style>

--- a/pages/conditions/[id].vue
+++ b/pages/conditions/[id].vue
@@ -7,12 +7,8 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
 
 export default {
-  components: {
-    MdViewer,
-  },
   data() {
     return {
       posts: [],
@@ -21,17 +17,17 @@ export default {
     };
   },
   mounted() {
+    const { id } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/conditions/${id}/`;
     return axios
-      .get(
-        `${useRuntimeConfig().public.apiUrl}/conditions/${
-          this.$route.params.id
-        }`
-      ) //you will need to enable CORS to make this work
-      .then((response) => {
-        this.condition = response.data;
+      .get(url) //you will need to enable CORS to make this work
+      .then((response) => (this.condition = response.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `${useRoute().path} does not exist`,
+        });
       });
   },
 };
 </script>
-
-<style lang="scss"></style>

--- a/pages/equipment/[section].vue
+++ b/pages/equipment/[section].vue
@@ -21,7 +21,6 @@ export default {
     return axios
       .get(url)
       .then((response) => {
-        console.log(response.status);
         this.section = response.data;
       })
       .catch(() => {

--- a/pages/equipment/[section].vue
+++ b/pages/equipment/[section].vue
@@ -1,37 +1,35 @@
 <template>
   <main v-if="section" class="docs-container container">
-    <h1>{{ title }}</h1>
+    <h1>{{ section.name }}</h1>
     <section>
       <md-viewer :text="section.desc" />
     </section>
   </main>
-  <p v-else>Loading...</p>
 </template>
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
 export default {
-  components: { MdViewer },
   data() {
     return {
-      title: '',
-      section: null,
+      section: undefined,
     };
   },
-
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/sections/${
-      this.$route.params.section
-    }`;
-
-    //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.section = response.data;
-      this.title = response.data.name;
-    });
+    const { section } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/sections/${section}/`;
+    return axios
+      .get(url)
+      .then((response) => {
+        console.log(response.status);
+        this.section = response.data;
+      })
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `The route ${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>
-
-<style></style>

--- a/pages/feats/[feat].vue
+++ b/pages/feats/[feat].vue
@@ -1,7 +1,7 @@
 <template>
   <main v-if="feat" class="docs-container container">
     <h1>
-      <span>{{ title }}</span>
+      <span>{{ feat.name }}</span>
       <source-tag
         v-if="feat.document__slug !== 'wotc-srd'"
         :text="feat.document__slug"
@@ -25,29 +25,25 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
-import SourceTag from '~/components/SourceTag';
 export default {
-  components: { MdViewer, SourceTag },
   data() {
-    return {
-      title: '',
-      feat: null,
-    };
+    return { feat: null };
   },
 
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/feats/${
-      this.$route.params.feat
-    }`;
+    const { feat } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/feats/${feat}/`;
 
     //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.feat = response.data;
-      this.title = response.data.name;
-    });
+    return axios
+      .get(url)
+      .then((response) => (this.feat = response.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `The route ${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>
-
-<style></style>

--- a/pages/feats/index.vue
+++ b/pages/feats/index.vue
@@ -34,7 +34,6 @@ export default {
     const url = `${useRuntimeConfig().public.apiUrl}/feats/`;
     //you will need to enable CORS to make this work
     return axios.get(url).then((response) => {
-      console.log(response.data);
       this.feats = response.data.results;
     });
   },

--- a/pages/gameplay-mechanics/[section].vue
+++ b/pages/gameplay-mechanics/[section].vue
@@ -1,6 +1,6 @@
 <template>
   <main v-if="section" class="docs-container container">
-    <h1>{{ title }}</h1>
+    <h1>{{ section.name }}</h1>
     <section>
       <md-viewer :text="section.desc" />
     </section>
@@ -10,28 +10,25 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '../../components/MdViewer.vue';
 export default {
-  components: { MdViewer },
   data() {
-    return {
-      title: '',
-      section: null,
-    };
+    return { section: null };
   },
 
   mounted() {
-    const url = `${useRuntimeConfig().public.apiUrl}/sections/${
-      this.$route.params.section
-    }`;
+    const { section } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/sections/${section}/`;
 
     //you will need to enable CORS to make this work
-    return axios.get(url).then((response) => {
-      this.section = response.data;
-      this.title = response.data.name;
-    });
+    return axios
+      .get(url)
+      .then((response) => (this.section = response.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `${useRoute().path} does not exist`,
+        });
+      });
   },
 };
 </script>
-
-<style></style>

--- a/pages/magic-items/[id].vue
+++ b/pages/magic-items/[id].vue
@@ -6,12 +6,12 @@
         {{ item.name }}
       </h1>
       <p>
-        <em
-          >{{ item.type }}, {{ item.rarity }}
-          <span v-show="item.requires_attunement"
-            >({{ item.requires_attunement }})</span
-          ></em
-        >
+        <em>
+          {{ item.type }}, {{ item.rarity }}
+          <span v-show="item.requires_attunement">
+            ({{ item.requires_attunement }})
+          </span>
+        </em>
         <source-tag
           v-show="item.document__slug"
           :title="item.document__title"
@@ -32,14 +32,8 @@
 
 <script>
 import axios from 'axios';
-import SourceTag from '~/components/SourceTag.vue';
-import MdViewer from '~/components/MdViewer.vue';
 
 export default {
-  components: {
-    MdViewer,
-    SourceTag,
-  },
   data() {
     return {
       item: [],
@@ -55,26 +49,20 @@ export default {
     },
   },
   mounted() {
+    const { id } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/magicitems/${id}/`;
     return axios
-      .get(
-        `${useRuntimeConfig().public.apiUrl}/magicitems/${
-          this.$route.params.id
-        }`
-      ) //you will need to enable CORS to make this work
+      .get(url) //you will need to enable CORS to make this work
       .then((response) => {
         this.item = response.data;
         this.loading = false;
+      })
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `${useRoute().path} does not exist`,
+        });
       });
   },
 };
 </script>
-
-<style scoped>
-label {
-  font-weight: bold;
-}
-
-.inline {
-  display: inline-block;
-}
-</style>

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -173,16 +173,8 @@
 
 <script>
 import axios from 'axios';
-import StatBonus from '~/components/StatBonus.vue';
-import ChallengeRender from '~/components/ChallengeRender.vue';
-import MdViewer from '~/components/MdViewer';
 
 export default {
-  components: {
-    StatBonus,
-    ChallengeRender,
-    MdViewer,
-  },
   data() {
     return {
       posts: [],
@@ -225,13 +217,19 @@ export default {
     },
   },
   created() {
+    const { id } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/monsters/${id}/`;
     return axios
-      .get(
-        `${useRuntimeConfig().public.apiUrl}/monsters/${this.$route.params.id}`
-      )
+      .get(url)
       .then((response) => {
         this.monster = response.data;
         this.loading = false;
+      })
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: 'This monster does not exist',
+        });
       });
   },
 };

--- a/pages/races/[id].vue
+++ b/pages/races/[id].vue
@@ -45,12 +45,8 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
 
 export default {
-  components: {
-    MdViewer,
-  },
   data() {
     return {
       posts: [],
@@ -61,15 +57,21 @@ export default {
     };
   },
   mounted() {
+    const { id } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/races/${id}/`;
     return axios
-      .get(`${useRuntimeConfig().public.apiUrl}/races/${this.$route.params.id}`) //you will need to enable CORS to make this work
+      .get(url) //you will need to enable CORS to make this work
       .then((response) => {
         this.race = response.data;
         this.loaded = true;
         this.subraceLength = this.race.subraces.length;
+      })
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `The page ${useRoute().path} does not exist`,
+        });
       });
   },
 };
 </script>
-
-<style lang="scss"></style>

--- a/pages/running/[id].vue
+++ b/pages/running/[id].vue
@@ -7,12 +7,8 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
 
 export default {
-  components: {
-    MdViewer,
-  },
   data() {
     return {
       posts: [],
@@ -21,15 +17,17 @@ export default {
     };
   },
   mounted() {
+    const { id } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/sections/${id}/`;
     return axios
-      .get(
-        `${this.$nuxt.$config.public.apiUrl}/sections/${this.$route.params.id}`
-      ) //you will need to enable CORS to make this work
-      .then((response) => {
-        this.section = response.data;
+      .get(url) //you will need to enable CORS to make this work
+      .then((response) => (this.section = response.data))
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `The page ${useRoute().path} does not exist`,
+        });
       });
   },
 };
 </script>
-
-<style lang="scss"></style>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -79,7 +79,7 @@
         <nuxt-link
           tag="a"
           :params="{ id: result.slug }"
-          :to="`/${result.route}${result.slug}`"
+          :to="`/magic-items/${result.slug}`"
         >
           {{ result.name }}
         </nuxt-link>

--- a/pages/sections/[...catchall].vue
+++ b/pages/sections/[...catchall].vue
@@ -1,0 +1,5 @@
+<template>
+  <!-- This route is not in active use and is only included to avoid  a 404 
+    -- error while the redirect middleware is fetching a section's parent -->
+  <p>Redirecting...</p>
+</template>

--- a/pages/spells/[id].vue
+++ b/pages/spells/[id].vue
@@ -47,12 +47,8 @@
 
 <script>
 import axios from 'axios';
-import MdViewer from '~/components/MdViewer';
 
 export default {
-  components: {
-    MdViewer,
-  },
   data() {
     return {
       spell: [],
@@ -69,13 +65,19 @@ export default {
     },
   },
   mounted() {
+    const { id } = useRoute().params;
+    const url = `${useRuntimeConfig().public.apiUrl}/spells/${id}/`;
     return axios
-      .get(
-        `${this.$nuxt.$config.public.apiUrl}/spells/${this.$route.params.id}`
-      ) //you will need to enable CORS to make this work
+      .get(url)
       .then((response) => {
         this.spell = response.data;
         this.loading = false;
+      })
+      .catch(() => {
+        throw showError({
+          statusCode: 404,
+          message: `The page ${useRoute().path} does not exist`,
+        });
       });
   },
 };

--- a/pages/spells/by-class/[charclass].vue
+++ b/pages/spells/by-class/[charclass].vue
@@ -48,13 +48,14 @@ export default {
       filter: '',
       isLoading: false,
       available_classes: [
-        'Bard',
-        'Cleric',
-        'Sorcerer',
-        'Wizard',
-        'Druid',
-        'Paladin',
-        'Warlock',
+        'bard',
+        'cleric',
+        'sorcerer',
+        'wizard',
+        'druid',
+        'paladin',
+        'warlock',
+        'ranger',
       ],
     };
   },
@@ -121,6 +122,14 @@ export default {
     },
   },
   mounted() {
+    // throw an error if the class is not a valid spellcasting class
+    if (!this.available_classes.includes(useRoute().params.charclass)) {
+      throw createError({
+        statusCode: 404,
+        fatal: true,
+        message: `The page ${useRoute().path} does not exist`,
+      });
+    }
     this.filter = this.$route.params.charclass;
     this.getSpells();
   },


### PR DESCRIPTION
This PR fixes two related bugs; 
**Bug 1**. Some redirects were not working as intended, specifically legacy links to the `/sections/[section]` route which should redirect to `/[section.parent]/[section]`.
**Bug 2**. The custom error page is no longer functioning

### Recreating the Bug
**Bug 1**. Navigate to https://open5e.com/sections/languages -- you get a 404 page instead of being redirected to https://open5e.com/characters/languages

**Bug 2**. As above. Notice that we get the generic Nuxt and not our custom error page. Additionally, if you attempt to navigate to a dynamic route with an invalid route parameter (ie. https://open5e.com/spells/test-123), the website doesn't redirect you to the error page when the server returns a 404 status code. Instead we never move beyond the loading screen:

<img width="480" alt="Screenshot 2023-08-29 at 15 43 25" src="https://github.com/open5e/open5e/assets/47755775/684a8097-a9b1-4127-be5c-8090144e38d0">

### Solutions
**Bug 1**. Update the `redirects.global.js` middleware to fetch a section's parent so that the user can be redirected to the correct route

**Bug 2**. The existing error page was set up to work in Nuxt 2, but moving to Nuxt 3 broke it. Moving  `error.vue` file from the `/layouts` to the root directory was enough to fix the error page for static routes. For dynamic routes it was necessary to handle the error using the `axios.catch()` method.

