### PR TITLE
Sources cleanup

### DIFF
--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -23,7 +23,7 @@
                     v-model="selectedSourcesComputed"
                     :name="document.slug"
                     type="checkbox"
-                    class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-600"
+                    class="h-4 w-4 rounded border-gray-300 text-blue-600 accent-blood focus:ring-blue-600"
                     :value="document.slug"
                   />
                 </div>
@@ -55,7 +55,7 @@
       </button>
       <button
         type="button"
-        class="inline-flex w-full justify-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 sm:col-start-2"
+        class="inline-flex w-full justify-center rounded-md bg-blood px-3 py-2 text-sm font-semibold text-white shadow-sm ring-offset-2 hover:ring-2 hover:ring-blood focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 sm:col-start-2"
         @click="saveSelection()"
       >
         Update

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -127,13 +127,6 @@ export default {
 
 <script setup>
 import { ref } from 'vue';
-import {
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-  TransitionChild,
-  TransitionRoot,
-} from '@headlessui/vue';
 
 const open = ref(true);
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -11,7 +11,7 @@
       >
         <!-- Logo -->
         <nuxt-link to="/" class="logo bg-red p-5 text-3xl">Open5e</nuxt-link>
-
+        <!-- SOURCE MODAL -->
         <div
           class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400 dark:bg-red-700 dark:hover:bg-red-600"
           @click="showModal = true"
@@ -29,6 +29,7 @@
             <Icon name="line-md:loading-twotone-loop" />
           </span>
         </div>
+        <!-- SEARCH BAR -->
         <div class="relative">
           <div
             class="absolute inset-y-0 right-0 flex cursor-pointer items-center pr-2"

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -1,7 +1,19 @@
 <template>
   <section class="docs-container container">
     <h1>Backgrounds</h1>
-    <div class="docs-toc">
+    <div
+      class="flex w-full flex-wrap pt-2 text-lg"
+      v-if="backgrounds.length == 0"
+    >
+      <div class="flex w-full">
+        There are no items for this category that align with the corresponding
+        sources you selected.
+      </div>
+      <div class="flex w-full pt-2">
+        Please edit your selected sources for more results.
+      </div>
+    </div>
+    <div class="docs-toc" v-else>
       <ul v-if="backgrounds">
         <li v-for="background in backgrounds" :key="background.slug">
           <nuxt-link tag="a" :to="`/backgrounds/${background.slug}`">

--- a/pages/characters/index.vue
+++ b/pages/characters/index.vue
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="docs-toc" v-else>
-      <ul v-if="charSections">
+      <ul>
         <li v-for="section in charSections" :key="section.slug">
           <nuxt-link tag="a" :to="`/characters/${section.slug}`">
             {{ section.name }}

--- a/pages/characters/index.vue
+++ b/pages/characters/index.vue
@@ -1,7 +1,19 @@
 <template>
   <section class="docs-container container">
     <h1>Creating Characters</h1>
-    <div class="docs-toc">
+    <div
+      class="flex w-full flex-wrap pt-2 text-lg"
+      v-if="charSections.length == 0"
+    >
+      <div class="flex w-full">
+        There are no items for this category that align with the corresponding
+        sources you selected.
+      </div>
+      <div class="flex w-full pt-2">
+        Please edit your selected sources for more results.
+      </div>
+    </div>
+    <div class="docs-toc" v-else>
       <ul v-if="charSections">
         <li v-for="section in charSections" :key="section.slug">
           <nuxt-link tag="a" :to="`/characters/${section.slug}`">

--- a/pages/combat/index.vue
+++ b/pages/combat/index.vue
@@ -1,7 +1,19 @@
 <template>
   <section class="docs-container container">
     <h1>Combat</h1>
-    <div class="docs-toc">
+    <div
+      class="flex w-full flex-wrap pt-2 text-lg"
+      v-if="combatSections.length == 0"
+    >
+      <div class="flex w-full">
+        There are no items for this category that align with the corresponding
+        sources you selected.
+      </div>
+      <div class="flex w-full pt-2">
+        Please edit your selected sources for more results.
+      </div>
+    </div>
+    <div class="docs-toc" v-else>
       <ul v-if="combatSections">
         <li v-for="section in combatSections" :key="section.slug">
           <nuxt-link tag="a" :to="`/combat/${section.slug}`">

--- a/pages/equipment/index.vue
+++ b/pages/equipment/index.vue
@@ -1,7 +1,19 @@
 <template>
   <section class="docs-container container">
     <h1>Equipment</h1>
-    <div class="docs-toc">
+    <div
+      class="flex w-full flex-wrap pt-2 text-lg"
+      v-if="equipmentSections.length == 0"
+    >
+      <div class="flex w-full">
+        There are no items for this category that align with the corresponding
+        sources you selected.
+      </div>
+      <div class="flex w-full pt-2">
+        Please edit your selected sources for more results.
+      </div>
+    </div>
+    <div class="docs-toc" v-else>
       <ul v-if="equipmentSections">
         <li v-for="section in equipmentSections" :key="section.slug">
           <nuxt-link tag="a" :to="`/equipment/${section.slug}`">

--- a/pages/gameplay-mechanics/index.vue
+++ b/pages/gameplay-mechanics/index.vue
@@ -1,7 +1,16 @@
 <template>
   <section class="docs-container container">
     <h1>Gameplay Mechanics</h1>
-    <div class="docs-toc">
+    <div class="flex w-full flex-wrap pt-2 text-lg" v-if="sections.length == 0">
+      <div class="flex w-full">
+        There are no items for this category that align with the corresponding
+        sources you selected.
+      </div>
+      <div class="flex w-full pt-2">
+        Please edit your selected sources for more results.
+      </div>
+    </div>
+    <div class="docs-toc" v-else>
       <ul v-if="sections">
         <li v-for="section in sections" :key="section.name">
           <nuxt-link tag="a" :to="`/gameplay-mechanics/${section.slug}`">

--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -1,7 +1,16 @@
 <template>
   <section class="docs-container container">
     <h1>Races</h1>
-    <div class="docs-toc">
+    <div class="flex w-full flex-wrap pt-2 text-lg" v-if="races.length == 0">
+      <div class="flex w-full">
+        There are no items for this category that align with the corresponding
+        sources you selected.
+      </div>
+      <div class="flex w-full pt-2">
+        Please edit your selected sources for more results.
+      </div>
+    </div>
+    <div class="docs-toc" v-else>
       <ul>
         <li v-for="race in races" :key="race.name">
           <nuxt-link tag="a" :to="`/races/${race.slug}`">

--- a/pages/running/index.vue
+++ b/pages/running/index.vue
@@ -1,7 +1,19 @@
 <template>
   <section class="docs-container container">
     <h1>Running a Game</h1>
-    <div class="docs-toc">
+    <div
+      class="flex w-full flex-wrap pt-2 text-lg"
+      v-if="Object.keys(sectionGroups).length == 0"
+    >
+      <div class="flex w-full">
+        There are no items for this category that align with the corresponding
+        sources you selected.
+      </div>
+      <div class="flex w-full pt-2">
+        Please edit your selected sources for more results.
+      </div>
+    </div>
+    <div class="docs-toc" v-else>
       <span v-if="$route.hash">{{ $route.hash }}</span>
       <ul>
         <li v-for="section in sectionGroups.Rules" :key="section.slug">


### PR DESCRIPTION
I did a bit of cleanup on some unused code in a couple of components. But for the most part, I added the following message to all of the pages except the `monsters` and `magic items` as those will take a bit more work and I'm waiting to see if they will be accepted or not. 

![image](https://github.com/open5e/open5e/assets/25889617/2a15fa4e-a25d-459a-8b60-4bb9f9313f3b)
