### PR TITLE
Added pagination. Component for controls and code on the page.

### DIFF
--- a/components/PageNav.vue
+++ b/components/PageNav.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="flex w-full flex-wrap align-middle">
+    <div class="flex w-full justify-start italic text-blood md:w-1/2">
+      Total of {{ listLength }} {{ listWording }}
+    </div>
+    <div class="flex w-full justify-end md:w-1/2">
+      <button
+        @click="firstPage()"
+        :disabled="pageNumber == 0"
+        class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+      >
+        <Icon name="heroicons:chevron-double-left" class="mr-1"></Icon>
+      </button>
+      <button
+        @click="prevPage()"
+        :disabled="pageNumber == 0"
+        class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+      >
+        <Icon name="heroicons:chevron-left" class="mr-1"></Icon>
+      </button>
+      <button
+        @click="nextPage()"
+        :disabled="pageNumber == pageCount - 1"
+        class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+      >
+        <Icon name="heroicons:chevron-right" class="mr-1"></Icon>
+      </button>
+      <button
+        @click="lastPage()"
+        :disabled="pageNumber == pageCount - 1"
+        class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+      >
+        <Icon name="heroicons:chevron-double-right" class="mr-1"></Icon>
+      </button>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    listLength: Number,
+    listWording: String,
+    pageCount: Number,
+    pageNumber: Number,
+  },
+  methods: {
+    firstPage() {
+      this.$emit('first');
+    },
+    lastPage() {
+      this.$emit('last');
+    },
+    nextPage() {
+      this.$emit('next');
+    },
+    prevPage() {
+      this.$emit('prev');
+    },
+  },
+};
+</script>

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -2,31 +2,18 @@
   <section class="container">
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Spell List</h1>
-      <filter-input
-        id="filter-spells"
-        ref="filter"
-        class="filter"
-        placeholder="Filter spells..."
-        @input="updateFilter"
-        @keyup.enter="onFilterEnter"
-      />
     </div>
+    <PageNav
+      @first="pageNumber = 0"
+      @last="pageNumber = pageCount - 1"
+      @next="pageNumber++"
+      @prev="pageNumber--"
+      :listLength="filteredSpells.length"
+      listWording="spells listed."
+      :pageNumber="pageNumber"
+      :pageCount="pageCount"
+    ></PageNav>
     <div>
-      <div>
-        <h2
-          ref="results"
-          class="sr-only"
-          tabindex="-1"
-          @keyup.esc="focusFilter"
-        >
-          {{ spellsListed.length }}
-          {{ spellsListed.length === 1 ? 'Result' : 'Results' }}
-          <span v-if="filter.length > 0">&nbsp;for {{ filter }}</span>
-        </h2>
-        <div aria-live="assertive" aria-atomic="true" class="sr-only">
-          <span v-if="spells.length && !spellsListed.length">No results.</span>
-        </div>
-      </div>
       <p v-if="!spells.length">Loading...</p>
       <table v-else class="filterable-table">
         <caption class="sr-only">
@@ -101,20 +88,28 @@
         </tbody>
       </table>
     </div>
-    <span style="display: none"
-      >Sorting by sort={{ currentSortProperty }}, dir={{ currentSortDir }}</span
-    >
+    <PageNav
+      @first="pageNumber = 0"
+      @last="pageNumber = pageCount - 1"
+      @next="pageNumber++"
+      @prev="pageNumber--"
+      :listLength="filteredSpells.length"
+      listWording="spells listed."
+      :pageNumber="pageNumber"
+      :pageCount="pageCount"
+    ></PageNav>
   </section>
 </template>
 
 <script>
 import FilterInput from '~/components/FilterInput.vue';
+import PageNav from '~/components/PageNav.vue';
 import SourceTag from '~/components/SourceTag.vue';
 import { useMainStore } from '~/store';
 
 export default {
   components: {
-    FilterInput,
+    PageNav,
     SourceTag,
   },
   setup() {
@@ -126,15 +121,21 @@ export default {
       filter: '',
       currentSortProperty: 'name',
       currentSortDir: 'ascending',
+      pageNumber: 0,
     };
   },
   computed: {
+    pageCount() {
+      return Math.ceil(this.spells.length / 50);
+    },
     spells: function () {
       return this.store.allSpells;
     },
     spellsListed: {
       get: function () {
-        return this.filteredSpells;
+        let start = this.pageNumber * 50;
+        let end = start + 50;
+        return this.filteredSpells.slice(start, end);
       },
       set: function () {
         return this.filteredSpells.sort((a, b) => {


### PR DESCRIPTION
I don't know if this is desired, however, the page responds MUCH faster when it is not trying to show over a thousand results at once. This paginates results on the spells page to 50 at a time and has the pagination controls broken out into a different component. 

If this is approved, I can begin incorporating these pieces into other large lists (e.g. items).