### PR TITLE
Bugfix: fix titles on /characters subroutes

### DIFF
--- a/pages/characters/[section].vue
+++ b/pages/characters/[section].vue
@@ -1,6 +1,6 @@
 <template>
   <main v-if="section" class="docs-container container">
-    <h1>{{ section.title }}</h1>
+    <h1>{{ section.name }}</h1>
     <section>
       <md-viewer :text="section.desc" />
     </section>


### PR DESCRIPTION
I noticed while browsing the website that the titles for pages in the `/characters` subroute were not displaying their titles correctly. 

<img width="1174" alt="Screenshot 2023-11-06 at 12 36 58" src="https://github.com/open5e/open5e/assets/47755775/55f07554-9ebc-4c41-8f85-c1a8823c03b3">


The issue was a key error when indexing into the data object returned by the API. The template referenced `section.title`, which doesn't exist on the object. Changing this to `section.name` fixed the bug.

<img width="1174" alt="Screenshot 2023-11-06 at 12 43 47" src="https://github.com/open5e/open5e/assets/47755775/6bf7eb07-d0da-4c8b-8b9e-20a080a09f8c">
