### PR TITLE
Display Bonus Actions for Monsters

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -131,6 +131,15 @@
         <b class="action-name">{{ action.name }}. </b>
         <md-viewer class="inline" :text="action.desc" />
       </p>
+      <h2 v-if="monster.bonus_actions">Bonus Actions</h2>
+      <p
+        v-for="bonus_action in monster.bonus_actions"
+        :key="bonus_action.name"
+        class="action-block"
+      >
+        <b class="action-name">{{ bonus_action.name }}. </b>
+        <md-viewer class="inline" :text="bonus_action.desc" />
+      </p>
       <h2 v-if="monster.reactions">Reactions</h2>
       <p
         v-for="action in monster.reactions"


### PR DESCRIPTION
Monsters that have bonus actions will now display them correctly on their page. Uses same styling as actions.
Bug spotted by Issue raised by Ankh on the [Discord](https://discord.com/channels/470638316103008268/1160455516191989830/1181755290870354091).