### PR TITLE
Bugfix: Fixing Linting Errors

### DIFF
--- a/components/PageNav.vue
+++ b/components/PageNav.vue
@@ -5,30 +5,30 @@
     </div>
     <div class="flex w-full justify-end md:w-1/2">
       <button
-        @click="firstPage()"
         :disabled="pageNumber == 0"
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+        @click="firstPage()"
       >
         <Icon name="heroicons:chevron-double-left" class="mr-1"></Icon>
       </button>
       <button
-        @click="prevPage()"
         :disabled="pageNumber == 0"
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+        @click="prevPage()"
       >
         <Icon name="heroicons:chevron-left" class="mr-1"></Icon>
       </button>
       <button
-        @click="nextPage()"
         :disabled="pageNumber == pageCount - 1"
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+        @click="nextPage()"
       >
         <Icon name="heroicons:chevron-right" class="mr-1"></Icon>
       </button>
       <button
-        @click="lastPage()"
         :disabled="pageNumber == pageCount - 1"
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
+        @click="lastPage()"
       >
         <Icon name="heroicons:chevron-double-right" class="mr-1"></Icon>
       </button>
@@ -38,10 +38,10 @@
 <script>
 export default {
   props: {
-    listLength: Number,
-    listWording: String,
-    pageCount: Number,
-    pageNumber: Number,
+    listLength: { type: Number, default: 0 },
+    listWording: { type: String, default: '' },
+    pageCount: { type: Number, default: 0 },
+    pageNumber: { type: Number, default: 0 },
   },
   methods: {
     firstPage() {

--- a/components/StatBonus.vue
+++ b/components/StatBonus.vue
@@ -8,11 +8,8 @@
 <script>
 export default {
   props: {
-    stat: Number,
-    type: {
-      type: String,
-      default: 'score',
-    },
+    stat: { type: Number, default: 0 },
+    type: { type: String, default: 'score' },
   },
   computed: {
     statBonus: function () {
@@ -25,5 +22,3 @@ export default {
   },
 };
 </script>
-
-<style></style>

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -2,8 +2,8 @@
   <section class="docs-container container">
     <h1>Backgrounds</h1>
     <div
-      class="flex w-full flex-wrap pt-2 text-lg"
       v-if="backgrounds.length == 0"
+      class="flex w-full flex-wrap pt-2 text-lg"
     >
       <div class="flex w-full">
         There are no items for this category that align with the corresponding
@@ -13,7 +13,7 @@
         Please edit your selected sources for more results.
       </div>
     </div>
-    <div class="docs-toc" v-else>
+    <div v-else class="docs-toc">
       <ul v-if="backgrounds">
         <li v-for="background in backgrounds" :key="background.slug">
           <nuxt-link tag="a" :to="`/backgrounds/${background.slug}`">

--- a/pages/characters/index.vue
+++ b/pages/characters/index.vue
@@ -2,8 +2,8 @@
   <section class="docs-container container">
     <h1>Creating Characters</h1>
     <div
-      class="flex w-full flex-wrap pt-2 text-lg"
       v-if="charSections.length == 0"
+      class="flex w-full flex-wrap pt-2 text-lg"
     >
       <div class="flex w-full">
         There are no items for this category that align with the corresponding
@@ -13,7 +13,7 @@
         Please edit your selected sources for more results.
       </div>
     </div>
-    <div class="docs-toc" v-else>
+    <div v-else class="docs-toc">
       <ul>
         <li v-for="section in charSections" :key="section.slug">
           <nuxt-link tag="a" :to="`/characters/${section.slug}`">

--- a/pages/combat/index.vue
+++ b/pages/combat/index.vue
@@ -2,8 +2,8 @@
   <section class="docs-container container">
     <h1>Combat</h1>
     <div
-      class="flex w-full flex-wrap pt-2 text-lg"
       v-if="combatSections.length == 0"
+      class="flex w-full flex-wrap pt-2 text-lg"
     >
       <div class="flex w-full">
         There are no items for this category that align with the corresponding
@@ -13,7 +13,7 @@
         Please edit your selected sources for more results.
       </div>
     </div>
-    <div class="docs-toc" v-else>
+    <div v-else class="docs-toc">
       <ul v-if="combatSections">
         <li v-for="section in combatSections" :key="section.slug">
           <nuxt-link tag="a" :to="`/combat/${section.slug}`">

--- a/pages/equipment/index.vue
+++ b/pages/equipment/index.vue
@@ -2,8 +2,8 @@
   <section class="docs-container container">
     <h1>Equipment</h1>
     <div
-      class="flex w-full flex-wrap pt-2 text-lg"
       v-if="equipmentSections.length == 0"
+      class="flex w-full flex-wrap pt-2 text-lg"
     >
       <div class="flex w-full">
         There are no items for this category that align with the corresponding
@@ -13,7 +13,7 @@
         Please edit your selected sources for more results.
       </div>
     </div>
-    <div class="docs-toc" v-else>
+    <div v-else class="docs-toc">
       <ul v-if="equipmentSections">
         <li v-for="section in equipmentSections" :key="section.slug">
           <nuxt-link tag="a" :to="`/equipment/${section.slug}`">
@@ -40,5 +40,3 @@ export default {
   },
 };
 </script>
-
-<style></style>

--- a/pages/gameplay-mechanics/index.vue
+++ b/pages/gameplay-mechanics/index.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="docs-container container">
     <h1>Gameplay Mechanics</h1>
-    <div class="flex w-full flex-wrap pt-2 text-lg" v-if="sections.length == 0">
+    <div v-if="sections.length == 0" class="flex w-full flex-wrap pt-2 text-lg">
       <div class="flex w-full">
         There are no items for this category that align with the corresponding
         sources you selected.
@@ -10,7 +10,7 @@
         Please edit your selected sources for more results.
       </div>
     </div>
-    <div class="docs-toc" v-else>
+    <div v-else class="docs-toc">
       <ul v-if="sections">
         <li v-for="section in sections" :key="section.name">
           <nuxt-link tag="a" :to="`/gameplay-mechanics/${section.slug}`">
@@ -37,4 +37,3 @@ export default {
   },
 };
 </script>
-<style></style>

--- a/pages/magic-items/index.vue
+++ b/pages/magic-items/index.vue
@@ -56,8 +56,8 @@
             <span class="mr-2 font-bold">REQUIRES ATTUNEMENT:</span>
             <input
               id="attunement"
-              type="checkbox"
               v-model="filters.attunement"
+              type="checkbox"
               name="attunement"
               class="mb-1 accent-blood"
             />

--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="docs-container container">
     <h1>Races</h1>
-    <div class="flex w-full flex-wrap pt-2 text-lg" v-if="races.length == 0">
+    <div v-if="races.length == 0" class="flex w-full flex-wrap pt-2 text-lg">
       <div class="flex w-full">
         There are no items for this category that align with the corresponding
         sources you selected.
@@ -10,7 +10,7 @@
         Please edit your selected sources for more results.
       </div>
     </div>
-    <div class="docs-toc" v-else>
+    <div v-else class="docs-toc">
       <ul>
         <li v-for="race in races" :key="race.name">
           <nuxt-link tag="a" :to="`/races/${race.slug}`">
@@ -39,5 +39,3 @@ export default {
   },
 };
 </script>
-
-<style></style>

--- a/pages/running/index.vue
+++ b/pages/running/index.vue
@@ -2,8 +2,8 @@
   <section class="docs-container container">
     <h1>Running a Game</h1>
     <div
-      class="flex w-full flex-wrap pt-2 text-lg"
       v-if="Object.keys(sectionGroups).length == 0"
+      class="flex w-full flex-wrap pt-2 text-lg"
     >
       <div class="flex w-full">
         There are no items for this category that align with the corresponding
@@ -13,7 +13,7 @@
         Please edit your selected sources for more results.
       </div>
     </div>
-    <div class="docs-toc" v-else>
+    <div v-else class="docs-toc">
       <span v-if="$route.hash">{{ $route.hash }}</span>
       <ul>
         <li v-for="section in sectionGroups.Rules" :key="section.slug">
@@ -51,5 +51,3 @@ export default {
   },
 };
 </script>
-
-<style></style>

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -4,15 +4,15 @@
       <h1 class="filter-header">Spell List</h1>
     </div>
     <PageNav
+      :list-length="filteredSpells.length"
+      list-wording="spells listed."
+      :page-number="pageNumber"
+      :page-count="pageCount"
       @first="pageNumber = 0"
       @last="pageNumber = pageCount - 1"
       @next="pageNumber++"
       @prev="pageNumber--"
-      :listLength="filteredSpells.length"
-      listWording="spells listed."
-      :pageNumber="pageNumber"
-      :pageCount="pageCount"
-    ></PageNav>
+    />
     <div>
       <p v-if="!spells.length">Loading...</p>
       <table v-else class="filterable-table">
@@ -89,15 +89,15 @@
       </table>
     </div>
     <PageNav
+      :list-length="filteredSpells.length"
+      list-wording="spells listed."
+      :page-number="pageNumber"
+      :page-count="pageCount"
       @first="pageNumber = 0"
       @last="pageNumber = pageCount - 1"
       @next="pageNumber++"
       @prev="pageNumber--"
-      :listLength="filteredSpells.length"
-      listWording="spells listed."
-      :pageNumber="pageNumber"
-      :pageCount="pageCount"
-    ></PageNav>
+    />
   </section>
 </template>
 


### PR DESCRIPTION
## Purpose

While working on another feature for the site, I couldn't help but notice my linter screaming at me:

<img width="400" alt="Screenshot of a terminal displaying many linting errors" src="https://github.com/open5e/open5e/assets/47755775/a11073bd-2c84-4178-a2e0-fe9920f09799">

The purpose of this PR is to fix as many of these linting errors a possible by. It brings the number of errors down from **47** to **3** by:

- Adding default values to component props
- Reordering attributes in HTML tags


### What about those last 3 linting errors?

The remaining errors were raised by `vue/no-v-html` linting rule on the `/search` page. In this case, the `v-html` directive is being used to render highlighted previews of search item, generated server-side and passed to the client-side as stringified  HTML.

If we wanted to fix these errors, we could find a safer way to handle HTML injection (perhaps by installing a sanitiser or some kind), or we could update the API so that it returns the preview in Markdown which can then be parsed on the front-end. In either case, this feels like it is outside the scope of this PR, which is otherwise a very simple refactor