### PR TITLE
Bugfix: fixed missing class name on classes/[className] route

### DIFF
--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -41,7 +41,7 @@
         {{ classData.prof_skills }}
       </p>
 
-      <h3>The {{ className }}</h3>
+      <h3>The {{ classData.name }}</h3>
       <md-viewer :text="classData.table" />
     </section>
 


### PR DESCRIPTION
## Recreating the Bug

If you navigate to any class on the live site, ie. the [Monk](https://open5e.com/classes/monk), you will see that the class name is missing from the header of the table of their level-by-level features.

<img width="600" alt="A screenshot from the Open5e website showing a visual bug in the header of a table" src="https://github.com/open5e/open5e/assets/47755775/d0e47d64-e19a-4723-90d6-cb4e91b0af90">

## Solution

The problem was an incorrect reference to the variable containing the class name in the template for the `classes/[className]` page. Fixing the typo resolved the bug.


<img width="600" alt="A screenshot from the Open5e website with the table heading bug fixed" src="https://github.com/open5e/open5e/assets/47755775/0595c4a7-ebec-4c58-846d-d4460e3cdae2">

