### PR TITLE
Bugfix: improving responsive site header styles

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -24,8 +24,6 @@ table {
 }
 
 .container {
-  margin: $pad-lg auto $pad-lg 0;
-  padding: 0 $pad-lg;
   h1 {
     font-size: 2rem;
     &:not(:first-child) {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -3,7 +3,7 @@
 @import 'docs';
 
 .side-note {
-  @apply sticky right-3 float-right m-2 w-80 border border-blue-600 bg-blue-100 p-2 text-blue-900 dark:border-smoke dark:bg-basalt dark:text-white;
+  @apply right-3 m-2 block w-full border border-blue-600 bg-blue-100 p-2 text-blue-900 dark:border-smoke dark:bg-basalt dark:text-white md:sticky md:float-right md:w-80 xl:right-8;
   h3 {
     @apply mt-0;
   }

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -1,25 +1,36 @@
 <template>
   <nav
-    class="md:text-md my-1 flex items-center border border-gray-200 px-2 py-0 align-middle text-sm font-semibold uppercase dark:border-basalt md:ml-8 md:px-4 md:py-2"
+    class="my-2 flex h-min items-center border-gray-200 py-0 align-middle dark:border-basalt sm:ml-8 sm:border sm:px-4 sm:py-2"
     aria-label="breadcrumbs"
   >
-    <ol class="space-x-3">
+    <ol class="space-x-1 text-xs font-semibold sm:space-x-3 lg:text-sm">
+      <!-- Prepend Home Link to list -->
+      <li
+        class="inline-flex items-center align-middle text-gray-700 after:ml-1 after:text-blood after:content-['/'] last:after:content-[''] visited:text-gray-700 hover:text-red-700 dark:text-gray-200 dark:visited:text-gray-200 dark:hover:text-red-400 sm:after:ml-4"
+      >
+        <!-- On narrow screens, home breadcrumb serves as site brand -->
+        <nuxt-link to="/">
+          <span
+            class="font-serif text-lg font-bold hover:text-red-700 dark:text-white dark:hover:text-red-200 sm:hidden"
+          >
+            Open5e
+          </span>
+          <span class="hidden align-middle uppercase sm:inline-flex">
+            <Icon name="heroicons:home" class="mt-0.5 align-middle sm:mr-1" />
+            Home
+          </span>
+        </nuxt-link>
+      </li>
+
+      <!-- Render Breadcrumbs -->
       <li
         v-for="crumb in crumbs"
         :key="crumb.url"
-        class="inline-flex h-10 items-center align-middle after:ml-4 after:text-blood after:content-['/'] last:after:content-['']"
+        class="inline-flex break-before-auto items-center align-middle uppercase text-gray-700 after:ml-1 after:text-blood after:content-['/'] last:after:content-[''] visited:text-gray-700 hover:text-red-700 dark:text-gray-200 dark:visited:text-gray-200 dark:hover:text-red-400 sm:after:ml-4"
       >
-        <nuxt-link
-          :to="crumb.url"
-          class="inline-flex items-center align-middle text-gray-700 visited:text-gray-700 hover:text-red-700 dark:text-gray-200 dark:visited:text-gray-200 dark:hover:text-red-400"
-        >
-          <Icon
-            v-if="crumb.title === 'Home'"
-            name="heroicons:home"
-            class="mr-1"
-          />
+        <nuxt-link :to="crumb.url" class="align-middle">
           <span>{{ crumb.title }}</span>
-          <span v-if="crumb.subtitle" class="ml-2 font-thin text-granite">
+          <span v-if="crumb.subtitle" class="font-thin text-granite sm:ml-2">
             ({{ crumb.subtitle }})
           </span>
         </nuxt-link>
@@ -28,44 +39,40 @@
   </nav>
 </template>
 
-<script>
-export default {
-  computed: {
-    crumbs() {
-      // iterate over segments of current path to create breadcrumbs
-      let url = '';
-      const breadcrumbs = this.$route.fullPath
-        .split('/')
-        .map((segment) => {
-          // ignore initial & trailing slashes
-          if (segment === '' || segment === '/') {
-            return;
-          }
+<script setup>
+import { useRoute } from 'nuxt/app';
+import { computed } from 'vue';
+const crumbs = computed(() => {
+  let url = '';
+  return useRoute()
+    .path.split('/')
+    .map((segment) => {
+      // ignore initial & trailing slashes
+      if (segment === '' || segment === '/') {
+        return;
+      }
 
-          // rebuild link urls segment by segment
-          url += `/${segment}`;
+      // rebuild link urls segment by segment
+      url += `/${segment}`;
 
-          // seperate segment title & query params
-          const [title, queryParams] = segment.split('?');
-          // extract & format the search params if on the /search route
-          const searchParam =
-            title === 'search' &&
-            queryParams.split('text=')[1].split('+').join(' ');
+      // seperate segment title & query params
+      const [title, queryParams] = segment.split('?');
 
-          return {
-            url,
-            title: title // format crumb title
-              .split('-')
-              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-              .join(' '),
-            subtitle: searchParam,
-          };
-        })
-        .filter((breadcrumb) => breadcrumb); // filter null crumbs
+      // extract & format the search params if on the /search route
+      const searchParam =
+        title === 'search' &&
+        queryParams.split('text=')[1].split('+').join(' ');
 
-      // prepend Home route to list of crumbs
-      return [{ title: 'Home', url: '/' }, ...breadcrumbs];
-    },
-  },
-};
+      // return a
+      return {
+        url,
+        title: title // format crumb title
+          .split('-')
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' '),
+        subtitle: searchParam,
+      };
+    })
+    .filter((breadcrumb) => breadcrumb);
+});
 </script>

--- a/components/SidebarToggle.vue
+++ b/components/SidebarToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="mx-2 mt-1 h-min rounded-full bg-fog px-4 py-3 hover:bg-smoke dark:bg-basalt hover:dark:bg-granite sm:hidden"
+    class="m-1 h-min rounded-full bg-fog px-3 py-2 hover:bg-smoke dark:bg-basalt hover:dark:bg-granite sm:hidden md:px-4 md:py-3"
   >
     <Icon name="heroicons:bars-3" class="text-center" />
   </button>

--- a/components/SidebarToggle.vue
+++ b/components/SidebarToggle.vue
@@ -1,0 +1,7 @@
+<template>
+  <button
+    class="mx-2 mt-1 h-min rounded-full bg-fog px-4 py-3 hover:bg-smoke dark:bg-basalt hover:dark:bg-granite sm:hidden"
+  >
+    <Icon name="heroicons:bars-3" class="text-center" />
+  </button>
+</template>

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -1,7 +1,8 @@
 <template>
-  <div>
+  <div class="mt-1">
     <button
-      class="mx-2 mt-1 h-min rounded-full bg-fog px-4 py-3 hover:bg-smoke dark:hidden"
+      class="mr-1 h-min rounded-full bg-fog px-3 py-2 hover:bg-smoke dark:hidden sm:mx-2 md:px-4 md:py-3"
+      aria-roledescription="Dark Mode Toggle"
       @click="handleClick"
     >
       <Icon
@@ -10,7 +11,8 @@
       />
     </button>
     <button
-      class="mx-2 mt-1 hidden h-min rounded-full bg-basalt px-4 py-3 text-white hover:bg-granite dark:block"
+      class="mr-1 hidden h-min rounded-full bg-basalt px-3 py-2 text-white hover:bg-granite dark:block sm:mx-2 md:px-4 md:py-3"
+      aria-roledescription="Light Mode Toggle"
       @click="handleClick"
     >
       <Icon
@@ -21,36 +23,32 @@
   </div>
 </template>
 
-<script>
-export default {
-  /* load theme preference before page and insert them into the head. This is to
-   * avoid flicker on load. 1st check local storage, then check media preferences
-   */
-
-  setup: function () {
-    useHead({
-      script: [
-        {
-          children: `if (localStorage.theme === "dark" || (!('theme' in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }`,
-        },
-      ],
-    });
-  },
-  methods: {
-    handleClick: () => {
-      const body = document.documentElement;
-      if (body.classList.contains('dark')) {
-        body.classList.remove('dark');
-        localStorage.setItem('theme', 'light');
-      } else {
-        body.classList.add('dark');
-        localStorage.setItem('theme', 'dark');
-      }
+<script setup>
+/* load theme preference before page and insert them into the head. This is to
+ * avoid flicker on load. 1st check local storage, then check media preferences
+ */
+useHead({
+  script: [
+    {
+      children: `
+          if (localStorage.theme === "dark" || (!('theme' in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+            document.documentElement.classList.add('dark')
+          } else {
+          document.documentElement.classList.remove('dark')
+          }
+        `,
     },
-  },
+  ],
+});
+
+const handleClick = () => {
+  const body = document.documentElement;
+  if (body.classList.contains('dark')) {
+    body.classList.remove('dark');
+    localStorage.setItem('theme', 'light');
+  } else {
+    body.classList.add('dark');
+    localStorage.setItem('theme', 'dark');
+  }
 };
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,15 +2,21 @@
   <div class="overflow-hidden text-darkness">
     <SourcesModal :show="showModal" @close="showModal = false" />
     <div
-      class="app-wrapper relative h-screen w-screen bg-white dark:bg-darkness"
-      :class="{ 'show-sidebar': showSidebar }"
+      class="grid h-screen w-screen grid-flow-col bg-white transition-all dark:bg-darkness sm:ml-0 sm:grid-cols-[14rem_1fr] sm:overflow-y-auto sm:transition-none"
+      :class="showSidebar ? 'ml-0' : '-ml-56'"
     >
       <!-- Sidebar -->
       <div
-        class="sidebar relative z-50 flex flex-col bg-slate-700 text-white dark:bg-slate-900"
+        class="z-50 flex w-56 flex-col overflow-y-auto bg-slate-700 text-white dark:bg-slate-900"
       >
         <!-- Logo -->
-        <nuxt-link to="/" class="logo bg-red p-5 text-3xl">Open5e</nuxt-link>
+        <nuxt-link
+          to="/"
+          class="bg-red p-5 font-serif text-3xl text-white hover:text-white"
+        >
+          Open5e
+        </nuxt-link>
+
         <!-- SOURCE MODAL -->
         <div
           class="cursor-pointer bg-red-600 px-4 py-2 hover:bg-red-400 dark:bg-red-700 dark:hover:bg-red-600"
@@ -68,10 +74,7 @@
         </ul>
 
         <!-- Patron Banner -->
-        <a
-          class="mt-auto inline-block self-end"
-          href="https://www.patreon.com/open5e"
-        >
+        <a href="https://www.patreon.com/open5e">
           <img
             src="/img/patron-badge.png"
             class="block w-full"
@@ -82,38 +85,33 @@
 
       <!-- Page central column -->
       <div
-        class="content-wrapper bg-white text-darkness dark:bg-darkness dark:text-white"
+        class="content-wrapper w-screen bg-white text-darkness dark:bg-darkness dark:text-white sm:w-full"
       >
         <!-- Mobile Header -->
-        <div
-          class="mobile-header sticky z-60 h-12 flex-row justify-between bg-red text-3xl dark:bg-red-800"
-        >
-          <div
-            class="sidebar-toggle flex h-full w-12 cursor-pointer items-center justify-center hover:bg-blood"
-            @click="toggleSidebar"
-          />
+
+        <div class="flex">
+          <sidebar-toggle @click="toggleSidebar" />
           <nuxt-link
             to="/"
-            class="logo mb-1 self-center font-serif text-lg font-bold text-white"
+            class="mb-1 flex self-center font-serif text-lg font-bold sm:hidden"
           >
             Open5e
           </nuxt-link>
-          <div class="h-12 w-12" />
+          <breadcrumb-links class="flex-grow" />
+          <theme-switcher class="inline-block" />
         </div>
 
         <!-- Shade: fades out main content when sidebar expanded on mobile -->
         <div
           v-show="showSidebar"
-          class="shade fixed left-0 top-0 z-48 h-full w-full bg-basalt/50"
+          class="fixed left-0 top-0 z-48 h-full w-full bg-basalt/50 sm:hidden"
           @click="hideSidebar"
         />
-        <div class="flex">
-          <breadcrumb-links class="flex-grow" />
-          <theme-switcher class="inline-block" />
-        </div>
 
         <!-- Main page content -->
-        <nuxt-page class="page-content text-darkness dark:text-white" />
+        <nuxt-page
+          class="main-content pt-auto mx-0 w-full px-4 py-4 pb-0 text-darkness dark:text-white sm:px-8"
+        />
       </div>
     </div>
   </div>
@@ -284,94 +282,9 @@ export default {
 <style lang="scss">
 @import '../assets/main';
 
-.shade {
-  display: none;
-}
-
-.app-wrapper {
-  display: flex;
-  flex-direction: row;
-  align-content: stretch;
-}
-
-.content-wrapper {
-  padding: $content-padding-y $content-padding-x;
-  overflow: auto;
-  flex-grow: 1;
-  max-width: 60rem;
-}
-.page-content {
-  * > a {
+.main-content {
+  a {
     @apply text-indigo-600 hover:text-blood hover:underline dark:text-indigo-200 dark:hover:text-red;
-  }
-}
-
-.logo {
-  font-family: Lora, serif;
-  display: block;
-}
-
-.mobile-header {
-  display: none;
-  width: calc(100% + 4rem);
-  margin: (-$content-padding-y) (-$content-padding-x) 0;
-}
-
-.sidebar {
-  width: $sidebar-width;
-  min-width: $sidebar-width;
-  overflow-y: auto;
-}
-
-.sidebar-toggle {
-  background-image: url('/img/menu-button.png');
-  background-size: 50%;
-  background-repeat: no-repeat;
-  background-position: center;
-}
-
-// These should be refactored using Tailwind breakpoints
-@media (max-width: 600px) {
-  .shade {
-    display: block;
-  }
-
-  .app-wrapper {
-    margin-left: -$sidebar-width;
-    transition: margin-left 250ms ease;
-
-    .mobile-header {
-      display: flex;
-    }
-
-    .container {
-      padding: 0;
-    }
-
-    .content-wrapper {
-      min-width: 100vw;
-    }
-
-    .sidebar {
-      min-width: $sidebar-width;
-    }
-  }
-
-  .app-wrapper.show-sidebar {
-    margin-left: 0;
-  }
-}
-
-@media (min-width: 1200px) {
-  .app-wrapper {
-    .content-wrapper {
-      max-width: calc(100vw - 24rem);
-      overflow-x: visible;
-
-      .side-note {
-        right: 2rem;
-      }
-    }
   }
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -85,18 +85,12 @@
 
       <!-- Page central column -->
       <div
-        class="content-wrapper w-screen bg-white text-darkness dark:bg-darkness dark:text-white sm:w-full"
+        class="content-wrapper w-screen overflow-y-auto bg-white text-darkness dark:bg-darkness dark:text-white sm:w-full"
       >
-        <!-- Mobile Header -->
+        <!-- Site Header -->
 
-        <div class="flex">
+        <div class="flex h-12 align-middle">
           <sidebar-toggle @click="toggleSidebar" />
-          <nuxt-link
-            to="/"
-            class="mb-1 flex self-center font-serif text-lg font-bold sm:hidden"
-          >
-            Open5e
-          </nuxt-link>
           <breadcrumb-links class="flex-grow" />
           <theme-switcher class="inline-block" />
         </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,9 +9,10 @@
       <a href="https://slyflourish.com/lazydm/">The Lazy Dungeon Master</a> is a
       masterwork of a guide for anyone aspiring to run Dungeons & Dragons or any
       RPG. Check out
-      <a href="https://slyflourish.com/top_advice.html"
-        >How to Be a Great D&D Dungeon Master</a
-      >, even if you're an expert. I can guarantee you'll learn something.
+      <a href="https://slyflourish.com/top_advice.html">
+        How to Be a Great D&D Dungeon Master
+      </a>
+      , even if you're an expert. I can guarantee you'll learn something.
     </p>
     <p>
       I'd also like to recommend
@@ -30,6 +31,13 @@
     </p>
 
     <h2>Supporting and Contributing</h2>
+
+    <h3>Contribute on Github</h3>
+    <p>
+      The Open5e <a href="https://github.com/open5e/open5e">site</a> and
+      <a href="https://github.com/open5e/open5e">API</a> are both open-source on
+      Github! Join us as a contributor and help develop new features and tools.
+    </p>
     <div class="side-note">
       <h3>Hey! Stuff is missing!</h3>
       <p>
@@ -42,13 +50,6 @@
         should add!
       </p>
     </div>
-
-    <h3>Contribute on Github</h3>
-    <p>
-      The Open5e <a href="https://github.com/open5e/open5e">site</a> and
-      <a href="https://github.com/open5e/open5e">API</a> are both open-source on
-      Github! Join us as a contributor and help develop new features and tools.
-    </p>
     <h4>Our tech stack</h4>
     <p>Want to know what you'd be getting into?</p>
     <p><b>DRF API server.</b> A powerful Python-based REST Framework.</p>
@@ -103,17 +104,6 @@
     </p>
   </section>
 </template>
-
-<script>
-export default {
-  data() {
-    return {
-      monsters: [],
-      spells: [],
-    };
-  },
-};
-</script>
 
 <style lang="scss">
 .external-button {


### PR DESCRIPTION
The PR fixes a number of UI bugs relating to the website Header and its responsive styles

## The Problem
On the `staging` branch, the UI at the top of the screen looks pretty wonky on small screens - especially with crumbs with long names. I tried to address this problem when I first implements the Breadcrumb links (PR #416), but the way that the CSS breakpoints were set up (a mixture of SASS media queries and Tailwind utility classes) but this fix way beyond the scope of that PR.

For example, here is what the [Hunter is Darkness Warlock patron](https://open5e.com/classes/warlock/hunter-in-darkness) looks like on the live site when viewed at a narrow screen width (320px). The theme picker and crumbs would look much better if they were inline with the nav toggle and site brand. Also, the line breaks in the breadcrumbs (inevitable on such a long route) could be handled more gracefully

<img width="321" alt="Screenshot 2024-01-13 at 18 26 51" src="https://github.com/open5e/open5e/assets/47755775/99c7eceb-3769-4f41-8960-2623928160a8">


## Solution 
The majority of the work undertaken involved refactoring the CSS that handled resposivity in the **Layout** components (`layouts/default.vue`). Media queries at the component and global level were replaced with CSS classes. Once there was done, at the UI components in the header could be brought inline and styled to look good on more website and mobile. 

<img width="324" alt="Screenshot 2024-01-13 at 18 27 19" src="https://github.com/open5e/open5e/assets/47755775/88a39dfd-7909-43d5-a14a-f5879ccaf88e">

NB. the changes to the header when viewed in a computer screen are largely unchanged.

I removed the red background from the Header because I think it looks nicer, but am happy to put it back if people disagree, or just think it is important to include for branding reasons? (Although perhaps a red border on the bottom edge would look nicer?)
