### PR TITLE
Several Changes to the Monster Page

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -37,11 +37,13 @@ table {
     border-bottom: 3px solid $color-fireball;
     padding-bottom: $pad-xs;
   }
+  h4 {
+    display: inline;
+  }
 
   h1,
   h2,
   h3,
-  h4,
   h5,
   h6 {
     display: flex;

--- a/assets/_typography.scss
+++ b/assets/_typography.scss
@@ -28,12 +28,6 @@ h3 {
   font-weight: 600;
 }
 
-h4,
-h5 {
-  font-weight: 800;
-  opacity: 0.7;
-}
-
 h2 {
   margin-top: $pad-md * 4;
 }
@@ -44,7 +38,12 @@ h3 {
 }
 
 h4 {
-  font-size: 1.2rem;
+  font-weight: 900;
+}
+
+h5 {
+  font-weight: 800;
+  opacity: 0.7;
 }
 
 h5 {

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -4,7 +4,9 @@
     <img v-if="monster.img_main" :src="monster.img_main" class="img-main" />
     <p class="italic">
       <span>
-        {{ `${monster.size} ${monster.type}, ${monster.alignment}` }}
+        {{
+          `${monster.size} ${monster.type} ${monster.subtype}, ${monster.alignment}`
+        }}
       </span>
       <source-tag
         v-show="monster.document__slug"
@@ -13,27 +15,25 @@
       />
     </p>
     <hr />
-    <p>
-      <span class="font-bold">Armor Class </span>
-      <span>{{ monster.armor_class }}</span>
-    </p>
-    <p>
-      <span class="font-bold">Hit Points </span>
-      <span>{{ `${monster.hit_points} (${monster.hit_dice})` }}</span>
-    </p>
-    <p>
-      <span class="pr-1 font-bold">Speed</span>
-      <span
-        v-for="(speed, key, index) in monster.speed"
-        v-show="key !== 'hover'"
-        :key="index"
+
+    <h4>Armor Class</h4>
+    <span>{{ `${monster.armor_class}, ${monster.armor_desc}` }}</span>
+    <p></p>
+    <h4>Hit Points</h4>
+    <span>{{ `${monster.hit_points} (${monster.hit_dice})` }}</span>
+    <p></p>
+    <h4>Speed</h4>
+    <span
+      v-for="(speed, key, index) in monster.speed"
+      v-show="key !== 'hover'"
+      :key="index"
+    >
+      {{ key.charAt(0).toUpperCase() + key.slice(1) }} {{ speed }}ft.
+      <span v-if="monster.speed.hasOwnProperty('hover') && key === 'fly'"
+        >(hover)</span
       >
-        {{ key.charAt(0).toUpperCase() + key.slice(1) }} {{ speed }}ft.
-        <span v-if="monster.speed.hasOwnProperty('hover') && key === 'fly'"
-          >(hover)</span
-        >
-      </span>
-    </p>
+    </span>
+
     <hr />
 
     <!-- ABILITY SCORES -->
@@ -43,99 +43,172 @@
         :key="ability.name"
         class="text-center"
       >
-        <div class="font-bold uppercase">{{ ability.shortName }}</div>
+        <h4 class="uppercase">{{ ability.shortName }}</h4>
         <div>{{ `${ability.score} (${formatMod(ability.modifier)})` }}</div>
       </div>
     </div>
 
     <hr />
 
-    <!-- SAVING THROWS -->
-    <p>
-      <span class="font-bold">Saving Throws</span>
-      <span v-for="ability in attributes" :key="ability.name">
-        <span class="capitalize before:content-['_']">
-          {{ ability.shortName }}
-        </span>
-        <span class="before:content-['_']">
-          {{ formatMod(ability.save) }}
-        </span>
-      </span>
-    </p>
+    <!-- SAVING THROWS AND ATTRIBUTES-->
 
-    <p v-if="monster.skills">
-      <b class="pr-1">Skills</b>
-      <span
-        v-for="(skill, key, index) in monster.skills"
-        v-show="key !== 'hover'"
-        :key="index"
-      >
-        {{ key.charAt(0).toUpperCase() + key.slice(1) }}
-        <span v-if="skill >= 0">+</span>{{ skill }}
-        <span v-if="index < monster.skills.length - 1">, </span>
+    <h4>Saving Throws</h4>
+    <span v-for="ability in attributes" :key="ability.name">
+      <span class="capitalize before:content-['_']">
+        {{ ability.shortName }}
       </span>
-    </p>
-    <p v-if="monster.damage_vulnerabilities">
-      <b class="pr-1">Damage Vulnerabilities</b>
-      {{ monster.damage_vulnerabilities }}
-    </p>
-    <p v-if="monster.damage_resistances">
-      <b>Damage Resistances</b> {{ monster.damage_resistances }}
-    </p>
-    <p v-if="monster.damage_immunities">
-      <b>Damage Immunities</b> {{ monster.damage_immunities }}
-    </p>
-    <p v-if="monster.senses"><b>Senses</b> {{ monster.senses }}</p>
-    <p v-if="monster.languages"><b>Languages</b> {{ monster.languages }}</p>
-    <p v-if="monster.challenge_rating">
-      <b class="pr-1">Challenge</b>
-      <challenge-render :challenge="monster.challenge_rating" />
-    </p>
+      <span class="before:content-['_']"> {{ formatMod(ability.save) }} </span>.
+    </span>
+    <p></p>
+    <h4 v-if="monster.skills" class="after:content-[': '] pr-1">Skills</h4>
+    <span
+      v-for="(skill, key, index) in monster.skills"
+      v-show="key !== 'hover'"
+      :key="index"
+    >
+      {{ key.charAt(0).toUpperCase() + key.slice(1) }}
+      <span v-if="skill >= 0">+</span>{{ skill }}.
+      <span v-if="index < monster.skills.length - 1">, </span>
+    </span>
+    <p></p>
+
+    <h4 v-if="monster.damage_vulnerabilities" class="after:content-[': '] pr-1">
+      Damage Vulnerabilities
+    </h4>
+    <span>{{ monster.damage_vulnerabilities }}</span>
+
+    <p></p>
+    <h4 v-if="monster.damage_resistances" class="after:content-[': '] pr-1">
+      Damage Resistances
+    </h4>
+    <span>{{ monster.damage_resistances }}</span>
+
+    <p></p>
+    <h4 v-if="monster.damage_immunities" class="after:content-[': '] pr-1">
+      Damage Immunities
+    </h4>
+    <span>{{ monster.damage_immunities }}</span>
+
+    <p></p>
+    <h4 v-if="monster.senses" class="after:content-[': '] pr-1">Senses</h4>
+    <span>{{ monster.senses }}</span>
+
+    <p></p>
+    <h4 v-if="monster.languages" class="after:content-[': '] pr-1">
+      Languages
+    </h4>
+    <span>{{ monster.languages }}</span>
+
+    <p></p>
+    <h4 v-if="monster.challenge_rating" class="after:content-[': '] pr-1">
+      Challenge
+    </h4>
+    <span><challenge-render :challenge="monster.challenge_rating" /></span>
+
     <hr />
-    <p
+
+    <!-- Monster Special Abilities -->
+
+    <h4
       v-for="ability in monster.special_abilities"
       :key="ability.name"
       class="action-block"
     >
-      <span class="font-bold">{{ ability.name }}. </span>
-      <md-viewer class="inline" :text="ability.desc" />
-    </p>
+      {{ ability.name }}.
+    </h4>
+    <md-viewer class="inline" :text="ability.desc" />
+
+    <!-- Monster Actions -->
     <h2 v-if="monster.actions">Actions</h2>
-    <p
+    <h4
       v-for="action in monster.actions"
       :key="action.name"
-      class="action-block"
+      class="action-block,action-name after:content-[': ']"
     >
-      <b class="action-name">{{ action.name }}. </b>
-      <md-viewer class="inline" :text="action.desc" />
-    </p>
+      {{ action.name }}.
+    </h4>
+    <md-viewer class="inline" :text="action.desc" />
+
+    <!-- Monster Bonus Actions -->
     <h2 v-if="monster.bonus_actions">Bonus Actions</h2>
-    <p
+    <h4
       v-for="bonus_action in monster.bonus_actions"
       :key="bonus_action.name"
-      class="action-block"
+      class="action-block, action-name after:content-[': ']"
     >
-      <b class="action-name">{{ bonus_action.name }}. </b>
-      <md-viewer class="inline" :text="bonus_action.desc" />
-    </p>
+      {{ bonus_action.name }}.
+    </h4>
+    <md-viewer class="inline" :text="bonus_action.desc" />
+
+    <!-- Monster Reactions -->
     <h2 v-if="monster.reactions">Reactions</h2>
-    <p
+    <h4
       v-for="action in monster.reactions"
       :key="action.name"
-      class="action-block"
+      class="action-block, action-name after:content-[': ']"
     >
-      <b class="action-name">{{ action.name }}. </b>
-      <md-viewer class="inline" :text="action.desc" />
-    </p>
+      {{ action.name }}.
+    </h4>
+    <md-viewer class="inline" :text="action.desc" />
+
+    <!-- Monster Legendary Actions -->
     <h2 v-if="monster.legendary_actions">Legendary Actions</h2>
-    <p
+    <p v-if="monster.legendary_desc" class="text">
+      {{ monster.legendary_desc }}
+    </p>
+
+    <h4
       v-for="action in monster.legendary_actions"
       :key="action.name"
-      class="action-block"
+      class="action-block, action-name after:content-[': ']"
     >
-      <b class="action-name">{{ action.name }}. </b>
-      <md-viewer class="inline" :text="action.desc" />
+      {{ action.name }}.
+    </h4>
+    <md-viewer class="inline" :text="action.desc" />
+
+    <!-- Monster Mythic Actions -->
+    <h2 v-if="monster.mythic_actions">Mythic Actions</h2>
+    <h4
+      v-for="actions in monster.mythic_actions"
+      :key="actions.name"
+      class="action-block, action-name after:content-[': ']"
+    >
+      {{ mythic_actions.name }}.
+    </h4>
+    <md-viewer class="inline" :text="mythic_actions.desc" />
+
+    <!-- Monster Lair and Lair Actions -->
+    <h2 v-if="monster.lair_actions">Lair Actions</h2>
+    <p v-if="monster.lair_desc" class="text">
+      {{ monster.lair_desc }}
     </p>
+
+    <h4
+      v-for="action in monster.lair_actions"
+      :key="action.name"
+      class="action-block, action-name after:content-[': ']"
+    >
+      {{ action.name }}.
+    </h4>
+    <md-viewer class="inline" :text="action.desc" />
+
+    <!-- Monster Description -->
+    <h2 v-if="monster.desc">Description</h2>
+    <p v-if="monster.desc" class="text"><md-viewer :text="monster.desc" /></p>
+
+    <!-- Monster Environments -->
+    <hr />
+
+    <h4>Environments:</h4>
+    <span
+      v-bind:key="item.id"
+      v-for="item in monster.environments"
+      class="text-sm after:content-['.'] [&:not(:last-child)]:after:content-[',_']"
+    >
+      {{ item }}
+    </span>
+    <p></p>
+
     <p class="text-sm italic">
       Source:
       <a target="NONE" :href="monster.document__url">

--- a/pages/monsters/compact/[id].vue
+++ b/pages/monsters/compact/[id].vue
@@ -4,9 +4,13 @@
     <div v-else class="compact">
       <b>{{ monster.name }}</b
       ><br />
-      <em>{{ monster.size }} {{ monster.type }}, {{ monster.alignment }} </em>
+      <em
+        >{{ monster.size }} {{ monster.type }} {{ monster.subtype }},
+        {{ monster.alignment }}
+      </em>
       <hr />
-      <b>Armor Class</b> {{ monster.armor_class }}<br />
+      <b>Armor Class</b> {{ monster.armor_class }} {{ monster.armor_desc
+      }}<br />
       <b>Hit Points</b> {{ monster.hit_points }} ({{ monster.hit_dice }})<br />
 
       <b class="pad-r-sm">Speed </b>

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -15,7 +15,7 @@ h3 {
 }
 
 h4 {
-  @apply text-lg;
+  @apply text-base;
 }
 
 h5 {


### PR DESCRIPTION
# /pages/monsters/[id].vue

> ## added:
- Monster Subtype
- Armor Description
- Legendary Description
- Mythic Actions
- Lair Description
- Lair Actions
- Monster Description
- Monster Environments
>## changed:
-  'h4' applied to all previously <b> to improve screen reading and facilitate future changes.
- improved readability of "Saving Throws"
- improved readability of "Skills"

# /pages/monsters/compact/[id].vue
> ## added:
- Monster Subtype
- Armor Description

# /assets/_docs.scss
>## changed:
- 'h4' set to inline

# /assets/_typography.scss
>## changed:
- 'h4' adjusted weight and size, removed opacity
- 'h5' moved in order to make the code easier to read

# /styles/tailwind.css
>## changed:
- 'h4' set to text-base