### PR TITLE
Bugfix: added Source Tags to /races route

### DIFF
--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -16,6 +16,11 @@
           <nuxt-link tag="a" :to="`/races/${race.slug}`">
             {{ race.name }}
           </nuxt-link>
+          <source-tag
+            v-if="race.document__slug !== 'wotc-srd'"
+            :text="race.document__slug"
+            :title="race.document__title"
+          />
         </li>
       </ul>
     </div>


### PR DESCRIPTION
### Recreating the Bug

When viewing the [backgrounds](https://open5e.com/backgrounds) or [feats](https://open5e.com/feats) routes on the Open5e site, any article not published by WOTC has a little source tag appended to it. However, if you look at the [races](https://open5e.com/races) route, these are missing.

<img width="480" alt="Screenshot 2024-01-18 at 11 39 55" src="https://github.com/open5e/open5e/assets/47755775/c7cf6970-e54f-45bb-91db-d022fcf7eb36">

### Solution

Very simple fix, we already have a `<source-tag>` component, it was just a case of dropping it in the `/pages/races/index.vue` page.

<img width="480" alt="Screenshot 2024-01-18 at 11 39 30" src="https://github.com/open5e/open5e/assets/47755775/7364f153-ea5a-4b60-a9a7-2916da387989">

