### PR TITLE
[FIX][OPEN5E][ISSUE-450] Fix for blank page on compact monster stat blocks

### DIFF
--- a/pages/monsters/compact/[id].vue
+++ b/pages/monsters/compact/[id].vue
@@ -109,7 +109,7 @@
         <b class="action-name">{{ action.name }}. </b>
         <md-viewer class="inline" :text="action.desc" />
       </p>
-      <p>Monster Reactions: {{ monster.reactions }}</p>
+
       <hr v-if="monster.reactions?.length > 0" />
       <b v-if="monster.reactions?.length > 0">Reactions</b>
       <p

--- a/pages/monsters/compact/[id].vue
+++ b/pages/monsters/compact/[id].vue
@@ -89,6 +89,7 @@
         <challenge-render :challenge="monster.challenge_rating" />
       </div>
 
+      <!-- Special Abilities -->
       <hr v-if="monster.special_abilities?.length > 0" />
       <p
         v-for="ability in monster.special_abilities"
@@ -99,6 +100,7 @@
         <md-viewer class="inline" :text="ability.desc" />
       </p>
 
+      <!-- Monster Actions -->
       <hr v-if="monster.actions.length > 0" />
       <b v-if="monster.actions.length > 0">Actions</b>
       <p
@@ -110,6 +112,7 @@
         <md-viewer class="inline" :text="action.desc" />
       </p>
 
+      <!-- Monster Reactions -->
       <hr v-if="monster.reactions?.length > 0" />
       <b v-if="monster.reactions?.length > 0">Reactions</b>
       <p
@@ -121,6 +124,7 @@
         <md-viewer class="inline" :text="action.desc" />
       </p>
 
+      <!-- Monster Legendary Actions -->
       <hr v-if="monster.legendary_actions?.length > 0" />
       <b v-if="monster.legendary_actions?.length > 0">Legendary Actions</b>
       <p

--- a/pages/monsters/compact/[id].vue
+++ b/pages/monsters/compact/[id].vue
@@ -58,7 +58,7 @@
           </span>
         </span>
       </div>
-      <div v-if="monster.skills.length > 0">
+      <div v-if="monster.skills?.length > 0">
         <b class="pad-r-sm">Skills </b>
         <span
           v-for="(skill, key, index) in monster.skills"
@@ -89,7 +89,7 @@
         <challenge-render :challenge="monster.challenge_rating" />
       </div>
 
-      <hr v-if="monster.special_abilities.length > 0" />
+      <hr v-if="monster.special_abilities?.length > 0" />
       <p
         v-for="ability in monster.special_abilities"
         :key="ability.name"
@@ -109,9 +109,9 @@
         <b class="action-name">{{ action.name }}. </b>
         <md-viewer class="inline" :text="action.desc" />
       </p>
-
-      <hr v-if="monster.reactions.length > 0" />
-      <b v-if="monster.reactions.length > 0">Reactions</b>
+      <p>Monster Reactions: {{ monster.reactions }}</p>
+      <hr v-if="monster.reactions?.length > 0" />
+      <b v-if="monster.reactions?.length > 0">Reactions</b>
       <p
         v-for="action in monster.reactions"
         :key="action.name"
@@ -121,8 +121,8 @@
         <md-viewer class="inline" :text="action.desc" />
       </p>
 
-      <hr v-if="monster.legendary_actions.length > 0" />
-      <b v-if="monster.legendary_actions.length > 0">Legendary Actions</b>
+      <hr v-if="monster.legendary_actions?.length > 0" />
+      <b v-if="monster.legendary_actions?.length > 0">Legendary Actions</b>
       <p
         v-for="action in monster.legendary_actions"
         :key="action.name"


### PR DESCRIPTION
Resolves [issue 450: Some compact stat blocks crashing](https://github.com/open5e/open5e/issues/450);

## Description
- Upon investigation, the issue seemed to be that the template for compact stat blocks was calling the length property of reactions and legendary actions, which return null from the data when undefined.  To resolve this issue, optional chaining was added to these property to prevent crashing.

## Proof
### Production Site
**Gnoll**
<img width="1512" alt="image" src="https://github.com/open5e/open5e/assets/9469597/ab156613-11fc-4583-824b-e6d8f720d12b">

**Aboleth**
<img width="1512" alt="image" src="https://github.com/open5e/open5e/assets/9469597/47003056-cbe2-4dd9-b22b-23c875ca3d94">

**Lich**
<img width="1509" alt="image" src="https://github.com/open5e/open5e/assets/9469597/53b06093-aa24-486e-8e45-adaa934071de">

### Local Site
**Gnoll**
<img width="1512" alt="image" src="https://github.com/open5e/open5e/assets/9469597/f70b92a6-19f1-4ab3-bfd3-8a0d57af9a37">

**Aboleth**
<img width="1512" alt="image" src="https://github.com/open5e/open5e/assets/9469597/fd239b2f-15a3-4a02-904e-3ed4f3089d9d">

**Lich**
<img width="1512" alt="image" src="https://github.com/open5e/open5e/assets/9469597/d84465dd-99db-451b-a1bb-58f98e5dc2a5">

