### PR TITLE
Set custom titles for all pages

### DIFF
--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -75,4 +75,19 @@ const crumbs = computed(() => {
     })
     .filter((breadcrumb) => breadcrumb);
 });
+
+const BASE_TITLE = 'Open5e';
+
+const title = computed(() => {
+  if (crumbs.value.length === 0) {
+    return BASE_TITLE;
+  }
+  return (
+    crumbs.value
+      .map((crumb) => crumb.title)
+      .toReversed()
+      .join(' - ') + ` - ${BASE_TITLE}`
+  );
+});
+useHead({ title: title });
 </script>

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -40,54 +40,5 @@
 </template>
 
 <script setup>
-import { useRoute } from 'nuxt/app';
-import { computed } from 'vue';
-const crumbs = computed(() => {
-  let url = '';
-  return useRoute()
-    .path.split('/')
-    .map((segment) => {
-      // ignore initial & trailing slashes
-      if (segment === '' || segment === '/') {
-        return;
-      }
-
-      // rebuild link urls segment by segment
-      url += `/${segment}`;
-
-      // seperate segment title & query params
-      const [title, queryParams] = segment.split('?');
-
-      // extract & format the search params if on the /search route
-      const searchParam =
-        title === 'search' &&
-        queryParams.split('text=')[1].split('+').join(' ');
-
-      // return a
-      return {
-        url,
-        title: title // format crumb title
-          .split('-')
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(' '),
-        subtitle: searchParam,
-      };
-    })
-    .filter((breadcrumb) => breadcrumb);
-});
-
-const BASE_TITLE = 'Open5e';
-
-const title = computed(() => {
-  if (crumbs.value.length === 0) {
-    return BASE_TITLE;
-  }
-  return (
-    crumbs.value
-      .map((crumb) => crumb.title)
-      .toReversed()
-      .join(' - ') + ` - ${BASE_TITLE}`
-  );
-});
-useHead({ title: title });
+const crumbs = inject('crumbs');
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -113,10 +113,62 @@
 
 <script>
 import { useMainStore } from '../store/index';
+import { useRoute } from 'nuxt/app';
+import { computed } from 'vue';
 
 export default {
   setup() {
     const store = useMainStore();
+
+    const crumbs = computed(() => {
+      let url = '';
+      return useRoute()
+        .path.split('/')
+        .map((segment) => {
+          // ignore initial & trailing slashes
+          if (segment === '' || segment === '/') {
+            return;
+          }
+
+          // rebuild link urls segment by segment
+          url += `/${segment}`;
+
+          // seperate segment title & query params
+          const [title, queryParams] = segment.split('?');
+
+          // extract & format the search params if on the /search route
+          const searchParam =
+            title === 'search' &&
+            queryParams.split('text=')[1].split('+').join(' ');
+
+          // return a
+          return {
+            url,
+            title: title // format crumb title
+              .split('-')
+              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+              .join(' '),
+            subtitle: searchParam,
+          };
+        })
+        .filter((breadcrumb) => breadcrumb);
+    });
+    provide('crumbs', crumbs);
+
+    const BASE_TITLE = 'Open5e';
+
+    const title = computed(() => {
+      if (crumbs.value.length === 0) {
+        return BASE_TITLE;
+      }
+      return (
+        crumbs.value
+          .map((crumb) => crumb.title)
+          .toReversed()
+          .join(' - ') + ` - ${BASE_TITLE}`
+      );
+    });
+    useHead({ title: title });
     return { store };
   },
   data() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -122,8 +122,9 @@ export default {
 
     const crumbs = computed(() => {
       let url = '';
+
       return useRoute()
-        .path.split('/')
+        .fullPath.split('/')
         .map((segment) => {
           // ignore initial & trailing slashes
           if (segment === '' || segment === '/') {


### PR DESCRIPTION
Closes #454. Uses the same logic as the breadcrumbs, only in reverse. Works for all pages.
![image](https://github.com/open5e/open5e/assets/43607012/8c888cd3-5c12-4043-97cf-e2f90ba3af08)
