### PR TITLE
Bugfix: Prettier & ESLint updates / fixing new linting errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,5 +26,18 @@ module.exports = {
     curly: 'error',
     quotes: ['error', 'single'],
     'vue/multi-word-component-names': 'off',
+    'vue/html-self-closing': [
+      'error',
+      {
+        html: {
+          normal: 'always',
+          component: 'always',
+          /* Vue advises that void tags omit the terminal slash, but this
+           * conflicts with Prettier */
+          // void: 'never',
+          void: 'always',
+        },
+      },
+    ],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,9 @@ module.exports = {
   },
   extends: [
     // https://github.com/vuejs/eslint-plugin-vue#priority-a-essential-error-prevention
-    // consider switching to `plugin:vue/strongly-recommended` or `plugin:vue/recommended` for stricter rules.
+    'plugin:vue/vue3-strongly-recommended',
+    'plugin:vue/strongly-recommended',
+    'plugin:vue/vue3-recommended',
     'plugin:vue/recommended',
     'prettier',
   ],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,5 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "proseWrap": "always"
 }

--- a/components/MagicItemFilterBox.vue
+++ b/components/MagicItemFilterBox.vue
@@ -20,13 +20,13 @@
             name="rarity"
             class="flex w-full rounded-md ring-1 ring-blood focus:ring-2 focus:ring-blood"
           >
-            <option :key="null" :value="null" text="Any"></option>
+            <option :key="null" :value="null" text="Any" />
             <option
               v-for="rtg in MAGIC_ITEMS_RARITES"
               :key="rtg"
               class=""
               v-text="rtg"
-            ></option>
+            />
           </select>
         </div>
         <div class="mt-2 flex w-full flex-wrap md:w-1/2">
@@ -37,13 +37,13 @@
             name="type"
             class="flex w-full rounded-md ring-1 ring-blood focus:ring-2 focus:ring-blood md:ml-2"
           >
-            <option :key="null" :value="null" text="Any"></option>
+            <option :key="null" :value="null" text="Any" />
             <option
               v-for="rtg in MAGIC_ITEMS_TYPES"
               :key="rtg"
               class=""
               v-text="rtg"
-            ></option>
+            />
           </select>
         </div>
         <div class="mt-4 flex w-full md:w-1/2">

--- a/components/MonsterFilterBox.vue
+++ b/components/MonsterFilterBox.vue
@@ -20,13 +20,13 @@
           name="challengeRtgLow"
           class="w-1/2 rounded-md ring-1 ring-blood focus:ring-2 focus:ring-blood"
         >
-          <option :key="null" :value="null" text="Any"></option>
+          <option :key="null" :value="null" text="Any" />
           <option
             v-for="[label, value] in MONSTER_CHALLENGE_RATINGS_MAP"
             :key="value"
             :value="value"
             v-text="label"
-          ></option>
+          />
         </select>
       </div>
       <div class="flex w-full px-1 md:w-1/2">
@@ -37,13 +37,13 @@
           name="challengeRtgHigh"
           class="w-1/2 rounded-md ring-1 ring-blood focus:ring-2 focus:ring-blood"
         >
-          <option :key="null" :value="null" text="Any"></option>
+          <option :key="null" :value="null" text="Any" />
           <option
             v-for="[label, value] in MONSTER_CHALLENGE_RATINGS_MAP"
             :key="value"
             :value="value"
             v-text="label"
-          ></option>
+          />
         </select>
       </div>
     </div>
@@ -84,12 +84,8 @@
         name="size"
         class="w-1/2 rounded-md ring-1 ring-blood focus:ring-2 focus:ring-blood"
       >
-        <option :key="null" :value="null" text="Any"></option>
-        <option
-          v-for="size in MONSTER_SIZES_LIST"
-          :key="size"
-          v-text="size"
-        ></option>
+        <option :key="null" :value="null" text="Any" />
+        <option v-for="size in MONSTER_SIZES_LIST" :key="size" v-text="size" />
       </select>
     </div>
     <div class="flex w-full flex-wrap pt-4 md:w-1/2">
@@ -101,12 +97,12 @@
           name="type"
           class="w-full rounded-md ring-1 ring-blood focus:ring-2 focus:ring-blood"
         >
-          <option :key="null" :value="null" text="Any"></option>
+          <option :key="null" :value="null" text="Any" />
           <option
             v-for="monsterType in MONSTER_TYPES_LIST"
             :key="monsterType"
             v-text="monsterType"
-          ></option>
+          />
         </select>
       </div>
     </div>

--- a/components/PageNav.vue
+++ b/components/PageNav.vue
@@ -9,28 +9,28 @@
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
         @click="firstPage()"
       >
-        <Icon name="heroicons:chevron-double-left" class="mr-1"></Icon>
+        <Icon name="heroicons:chevron-double-left" class="mr-1" />
       </button>
       <button
         :disabled="pageNumber == 0"
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
         @click="prevPage()"
       >
-        <Icon name="heroicons:chevron-left" class="mr-1"></Icon>
+        <Icon name="heroicons:chevron-left" class="mr-1" />
       </button>
       <button
         :disabled="pageNumber == pageCount - 1"
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
         @click="nextPage()"
       >
-        <Icon name="heroicons:chevron-right" class="mr-1"></Icon>
+        <Icon name="heroicons:chevron-right" class="mr-1" />
       </button>
       <button
         :disabled="pageNumber == pageCount - 1"
         class="mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood"
         @click="lastPage()"
       >
-        <Icon name="heroicons:chevron-double-right" class="mr-1"></Icon>
+        <Icon name="heroicons:chevron-double-right" class="mr-1" />
       </button>
     </div>
   </div>

--- a/components/SortableTableHeader.vue
+++ b/components/SortableTableHeader.vue
@@ -2,14 +2,15 @@
   <th :aria-sort="currentSortDir" class="sortable-table-header">
     <button @click="onClick">
       <span class="label">
-        <slot></slot>
+        <slot />
       </span>
       <span
         aria-hidden="true"
         class="arrow"
         :class="{ 'arrow--visible': currentSortDir }"
-        >{{ isAscending ? '▲' : '▼' }}</span
       >
+        {{ isAscending ? '▲' : '▼' }}
+      </span>
     </button>
   </th>
 </template>

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -31,12 +31,10 @@
                   <label
                     :for="document.slug"
                     class="font-medium text-gray-900 dark:text-white"
-                    >{{ document.title }}</label
                   >
-                  <SourceTag
-                    :title="document.title"
-                    :text="document.slug"
-                  ></SourceTag>
+                    {{ document.title }}
+                  </label>
+                  <SourceTag :title="document.title" :text="document.slug" />
                 </div>
               </div>
             </div>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "prepare": "husky install",
+    "format": "npx prettier --write .",
     "lint": "npm run lint:js && npm run lint:prettier",
     "lint:ci": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lint:js": "eslint --ext '.js,.vue' --ignore-path .gitignore .",

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -31,28 +31,37 @@
             <sortable-table-header
               :current-sort-dir="ariaSort.name"
               @sort="(dir) => sort('name', dir)"
-              >Name</sortable-table-header
             >
+              Name
+            </sortable-table-header>
+
             <sortable-table-header
               :current-sort-dir="ariaSort.type"
               @sort="(dir) => sort('type', dir)"
-              >Type</sortable-table-header
             >
+              Type
+            </sortable-table-header>
+
             <sortable-table-header
               :current-sort-dir="ariaSort.challenge_rating"
               @sort="(dir) => sort('cr', dir)"
-              >CR</sortable-table-header
             >
+              CR
+            </sortable-table-header>
+
             <sortable-table-header
               :current-sort-dir="ariaSort.size"
               @sort="(dir) => sort('size', dir)"
-              >Size</sortable-table-header
             >
+              Size
+            </sortable-table-header>
+
             <sortable-table-header
               :current-sort-dir="ariaSort.hit_points"
               @sort="(dir) => sort('hit_points', dir)"
-              >Hit Points</sortable-table-header
             >
+              Hit Points
+            </sortable-table-header>
           </tr>
         </thead>
         <tbody>

--- a/pages/races/[id].vue
+++ b/pages/races/[id].vue
@@ -14,8 +14,8 @@
       Source:
       <a target="NONE" :href="race.document__url">
         <span>{{ race.document__title }}</span>
-        <Icon name="heroicons:arrow-top-right-on-square-20-solid"></Icon
-      ></a>
+        <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
+      </a>
     </p>
 
     <h2 v-if="subraceLength > 0">Subraces</h2>

--- a/pages/spells/[id].vue
+++ b/pages/spells/[id].vue
@@ -39,7 +39,7 @@
       Source:
       <a target="NONE" :href="spell.document__url">
         {{ spell.document__title }}
-        <Icon name="heroicons:arrow-top-right-on-square-20-solid"></Icon>
+        <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
       </a>
     </p>
   </section>


### PR DESCRIPTION
This PR closes #410 by adjusting the Prettier and ESLint configs so that;

1) The linter catches a lot more dodgy formatting.
2) Prettier & ESLint are not fighting (ie. ESLint highlights an error due to Prettier's formatting)

The bulk of the work in this PR involved fixing the numerous new linter errors introduced by the changes. This is why there are so many small changes across many files.

The only point in the original issue which has not been addressed is how to style overlong strings of Tailwind classes. From my research, there doesn't appear to be a clear consensus on how to manage this. And as any solution would be highly opinionated, it probably ought to be discussed first