### PR TITLE
Fix site generation errors due to Array.toReversed

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -162,12 +162,10 @@ export default {
       if (crumbs.value.length === 0) {
         return BASE_TITLE;
       }
-      return (
-        crumbs.value
-          .map((crumb) => crumb.title)
-          .toReversed()
-          .join(' - ') + ` - ${BASE_TITLE}`
-      );
+      const crumb_titles = crumbs.value.map((crumb) => crumb.title);
+      const reversed_titles = [...crumb_titles].reverse();
+
+      return reversed_titles.join(' - ') + ` - ${BASE_TITLE}`;
     });
     useHead({ title: title });
     return { store };


### PR DESCRIPTION
In my previous PR I used `Array.toReversed`, which turns out is not supported in Node 16. This creates issues when trying to generate the site using GH actions, which be seen here: https://github.com/open5e/open5e/actions/runs/7891045830/job/21534539552#step:6:186

This uses `Array.reverse` on a copy of the array instead.