### PR TITLE
Stop search page crashing when there is no search parameter.

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -138,9 +138,10 @@ export default {
           const [title, queryParams] = segment.split('?');
 
           // extract & format the search params if on the /search route
-          const searchParam =
-            title === 'search' &&
-            queryParams.split('text=')[1].split('+').join(' ');
+          let searchParam = '';
+          if (title === 'search' && queryParams) {
+            searchParam = queryParams.split('text=')[1].split('+').join(' ');
+          }
 
           // return a
           return {

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -140,6 +140,11 @@ export default {
   },
   computed: {
     orderedResults: function () {
+      // Abort early if there is no search term
+      if (!this.text) {
+        return this.results;
+      }
+
       let tmp = this.results.slice();
       const term = this.text.toUpperCase();
       let first = [];


### PR DESCRIPTION
When `npm generate` is generating the search page, it does not add a search query. this causes the PR validation GH action to fail. I though I fixed this in PR #462, but it turns out the breadcrumbs function and the search result ordering both relied on the search query being there.

This is just a quick fix to let the PR validation function again, but the handling of search queries and breadcrumbs could do with more work at a later date.