### PR TITLE
Monster saves only display if monster has proficiency

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -291,7 +291,6 @@ const abilites = [
   shortName: ability.slice(0, 3),
   score: monster[ability],
   modifier: formatMod(calcMod(monster[ability])),
-  // save: monster[`${ability}_save`] ?? calcMod(monster[ability]),
   save: monster[`${ability}_save`],
 }));
 </script>

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -47,7 +47,7 @@
     <!-- ABILITY SCORES -->
     <section class="max-w-96">
       <ul class="flex items-center gap-4 text-center">
-        <li v-for="ability in abilites" :key="ability.name">
+        <li v-for="ability in abilities" :key="ability.name">
           <span class="block font-bold uppercase">{{ ability.shortName }}</span>
           <span>{{ `${ability.score} (${ability.modifier})` }} </span>
         </li>
@@ -59,18 +59,20 @@
     <!-- SAVING THROWS AND ATTRIBUTES-->
     <section>
       <ul>
-        <li>
+        <li v-if="abilities.filter((a) => a.save).length">
           <span class="font-bold">Saving Throws </span>
+
           <span
-            v-for="ability in abilites.filter((a) => a.save)"
+            v-for="ability in abilities.filter((a) => a.save)"
             :key="ability.name"
+            class="after:content-[','] last:after:content-[]"
           >
             <span class="capitalize before:content-['_']">
               {{ ability.shortName }}
             </span>
             <span class="before:content-['_']">
-              {{ formatMod(ability.save) }} </span
-            >.
+              {{ formatMod(ability.save) }}
+            </span>
           </span>
         </li>
 
@@ -80,10 +82,10 @@
             v-for="(skill, key, index) in monster.skills"
             v-show="key !== 'hover'"
             :key="index"
+            class="capitalize before:content-['_'] after:content-[','] last:after:content-[]"
           >
-            {{ key.charAt(0).toUpperCase() + key.slice(1) }}
-            <span v-if="skill >= 0">+</span>{{ skill }}.
-            <span v-if="index < monster.skills.length - 1">, </span>
+            {{ key }}
+            <span v-if="skill >= 0">+</span>{{ skill }}
           </span>
         </li>
 
@@ -126,7 +128,11 @@
         class="action-block"
       >
         <span class="font-bold after:content-['.']">{{ ability.name }}</span>
-        <md-viewer inline="true" :text="ability.desc" />
+        <md-viewer
+          :inline="true"
+          :text="ability.desc"
+          class="before:content-['_']"
+        />
       </p>
     </section>
 
@@ -279,7 +285,7 @@ const calcMod = (score) => Math.floor((score - 10) / 2);
 const formatMod = (mod) => (mod >= 0 ? '+' + mod.toString() : mod.toString());
 
 // Collect ability scores, saving throws, &c in one array
-const abilites = [
+const abilities = [
   'strength',
   'dexterity',
   'constitution',

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -61,7 +61,10 @@
       <ul>
         <li>
           <span class="font-bold">Saving Throws </span>
-          <span v-for="ability in abilites" :key="ability.name">
+          <span
+            v-for="ability in abilites.filter((a) => a.save)"
+            :key="ability.name"
+          >
             <span class="capitalize before:content-['_']">
               {{ ability.shortName }}
             </span>
@@ -288,7 +291,8 @@ const abilites = [
   shortName: ability.slice(0, 3),
   score: monster[ability],
   modifier: formatMod(calcMod(monster[ability])),
-  save: monster[`${ability}_save`] ?? calcMod(monster[ability]),
+  // save: monster[`${ability}_save`] ?? calcMod(monster[ability]),
+  save: monster[`${ability}_save`],
 }));
 </script>
 

--- a/pages/monsters/compact/[id].vue
+++ b/pages/monsters/compact/[id].vue
@@ -169,24 +169,15 @@ export default {
         { name: 'intelligence', display: 'Int' },
         { name: 'wisdom', display: 'Wis' },
         { name: 'charisma', display: 'Cha' },
-      ];
+      ].filter((save) => this.monster[save.name + '_save']);
       // build an object of save bonuses if they exist
       for (let i = 0; i < savesArray.length; i++) {
         const saveValue = this.monster[savesArray[i].name + '_save'];
-        const statValue = this.monster[savesArray[i].name];
-        if (saveValue !== null) {
-          saves.push({
-            name: savesArray[i].display,
-            val: saveValue,
-            type: 'bonus',
-          });
-        } else {
-          saves.push({
-            name: savesArray[i].display,
-            val: statValue,
-            type: 'score',
-          });
-        }
+        saves.push({
+          name: savesArray[i].display,
+          val: saveValue,
+          type: 'bonus',
+        });
       }
 
       return saves;

--- a/pages/monsters/compact/[id].vue
+++ b/pages/monsters/compact/[id].vue
@@ -48,14 +48,15 @@
 
       <hr />
 
-      <div v-if="getSaves">
+      <div v-if="getSaves.length">
         <b class="pad-r-sm">Saving Throws </b>
-        <span v-for="(save, index) in getSaves" :key="save.name">
+        <span
+          v-for="save in getSaves"
+          :key="save.name"
+          class="after:content-[',_'] last:after:content-[]"
+        >
           {{ save.name }}
-          <stat-bonus :stat="save.val" :type="save.type" /><span
-            v-show="index < getSaves.length - 1"
-            >,
-          </span>
+          <stat-bonus :stat="save.val" :type="save.type" />
         </span>
       </div>
       <div v-if="monster.skills?.length > 0">
@@ -161,26 +162,22 @@ export default {
   },
   computed: {
     getSaves() {
-      let saves = [];
-      let savesArray = [
+      return [
         { name: 'strength', display: 'Str' },
         { name: 'dexterity', display: 'Dex' },
         { name: 'constitution', display: 'Con' },
         { name: 'intelligence', display: 'Int' },
         { name: 'wisdom', display: 'Wis' },
         { name: 'charisma', display: 'Cha' },
-      ].filter((save) => this.monster[save.name + '_save']);
-      // build an object of save bonuses if they exist
-      for (let i = 0; i < savesArray.length; i++) {
-        const saveValue = this.monster[savesArray[i].name + '_save'];
-        saves.push({
-          name: savesArray[i].display,
-          val: saveValue,
-          type: 'bonus',
+      ]
+        .filter((save) => this.monster[save.name + '_save'])
+        .map((val) => {
+          return {
+            name: val.display,
+            val: this.monster[val.name + '_save'],
+            type: 'bonus',
+          };
         });
-      }
-
-      return saves;
     },
   },
   created() {


### PR DESCRIPTION
Saving throws are now only listed when the monster has proficiency in the save (which the API signals by having `number|null` on the `[ability]_save` property

Aboleth saving throws on D&D Beyond:

<img width="1224" alt="Screenshot 2024-02-24 at 9 55 46 am" src="https://github.com/open5e/open5e/assets/1767439/8a1170c5-a18f-4d2a-992b-98afcea6fc09">

Updated saving throws on Open5E:

<img width="1069" alt="Screenshot 2024-02-24 at 9 58 01 am" src="https://github.com/open5e/open5e/assets/1767439/b97f359c-5e9b-49a0-b751-c30722f17d6b">

<img width="912" alt="Screenshot 2024-02-24 at 9 55 59 am" src="https://github.com/open5e/open5e/assets/1767439/9774bc77-5876-43ea-b58b-14cb89c29f7a">
