### PR TITLE
Bugfix: feature table missing titles on class/[id] route

### DIFF
--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -41,7 +41,7 @@
         {{ classData.prof_skills }}
       </p>
 
-      <h3>The {{ className }}</h3>
+      <h3>The {{ classData.name }}</h3>
       <md-viewer :text="classData.table" />
     </section>
 


### PR DESCRIPTION
Fixed this in a previous PR (#445), but accidently nuked my fork before it was merged. Oops.

### Recreation

If you navigate to any class on the live site, ie. the [Monk](https://open5e.com/classes/monk), you will see that the class name is missing from the header of the table of their level-by-level features.

### Solution

The problem was an incorrect reference to the variable containing the class name in the template for the classes/[className] page. Fixing the typo resolved the bug.