### PR TITLE
Add condition immuity to monster page

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -135,9 +135,9 @@
         </li>
 
         <li v-if="monster.condition_immunities">
-          <span class="font-bold after:content-['_']"
-            >Condition Immunities</span
-          >
+          <span class="font-bold after:content-['_']">
+            Condition Immunities
+          </span>
           {{ monster.condition_immunities }}
         </li>
 

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -134,6 +134,13 @@
           {{ monster.damage_immunities }}
         </li>
 
+        <li v-if="monster.condition_immunities">
+          <span class="font-bold after:content-['_']"
+            >Condition Immunities</span
+          >
+          {{ monster.condition_immunities }}
+        </li>
+
         <li v-if="monster.senses">
           <span class="font-bold after:content-['_']">Senses</span>
           {{ monster.senses }}


### PR DESCRIPTION
Resolves #471.
Added condition immunities that was missing from the monster page.

![image](https://github.com/open5e/open5e/assets/86654557/7a0f03c2-fc27-466c-9970-a1dc41421034)
