### PR TITLE
fix: Monster skills not showing

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -102,8 +102,7 @@
             {{ formatMod(ability.save) }}
           </span>
         </li>
-
-        <li v-if="monster.skills.length">
+        <li v-if="monster.skills">
           <span class="font-bold after:content-['_']">Skills</span>
 
           <span


### PR DESCRIPTION
Fixes #475. `monster.skills` is an object, not an array. Checking for a `length` property will always return `false` and hide the skills. This could have been avoided with more strict use of Typescript.