### PR TITLE
Feature: Search Scoped to Sources

### DIFF
--- a/components/SearchPreview.vue
+++ b/components/SearchPreview.vue
@@ -1,0 +1,98 @@
+<template>
+  <!-- Monster summary includes mini statblock -->
+  <div v-if="result.route == 'monsters/'">
+    <p>
+      <nuxt-link
+        tag="a"
+        :params="{ id: result.slug }"
+        :to="`/${result.route}${result.slug}`"
+        class="font-bold"
+      >
+        {{ result.name }}
+      </nuxt-link>
+      <span>{{ ` CR ${result.challenge_rating} | ` }} </span>
+      <em>{{ `${result.hit_points}hp, AC ${result.armor_class}` }}</em>
+      <source-tag
+        v-if="result.document_slug !== 'wotc-srd'"
+        :title="result.document_title"
+        :text="result.document_slug"
+      />
+    </p>
+    <stat-bar
+      class="mt-1 block border-t pt-1"
+      :stats="{
+        str: result.strength,
+        dex: result.dexterity,
+        con: result.constitution,
+        int: result.intelligence,
+        wis: result.wisdom,
+        cha: result.charisma,
+      }"
+    />
+  </div>
+
+  <!-- Spells including basic spell info -->
+  <div v-else-if="result.route == 'spells/'">
+    <nuxt-link
+      tag="a"
+      :params="{ id: result.slug }"
+      :to="`/${result.route}${result.slug}`"
+      class="font-bold"
+    >
+      {{ result.name }}
+    </nuxt-link>
+    {{ `${result.school} spell | ${result.dnd_class}` }}
+    <source-tag
+      v-if="result.document_slug !== 'wotc-srd'"
+      :title="result.document_title"
+      :text="result.document_slug"
+    />
+    <p v-html="result.highlighted" />
+  </div>
+
+  <!-- Result summary for magic items -->
+  <div v-else-if="result.route == 'magicitems/'">
+    <nuxt-link
+      tag="a"
+      :params="{ id: result.slug }"
+      :to="`/magic-items/${result.slug}`"
+      class="font-bold"
+    >
+      {{ result.name }}
+    </nuxt-link>
+    {{ `${result.type}, ${result.rarity}` }}
+    <source-tag
+      v-if="result.document_slug !== 'wotc-srd'"
+      :title="result.document_title"
+      :text="result.document_slug"
+    />
+    <p v-html="result.highlighted" />
+  </div>
+
+  <!-- Result summary for everything else -->
+  <div v-else>
+    <nuxt-link
+      tag="a"
+      :params="{ id: result.slug }"
+      :to="`/${result.route}${result.slug}`"
+      class="font-bold"
+    >
+      {{ result.name }}
+    </nuxt-link>
+    <source-tag
+      v-if="result.document_slug !== 'wotc-srd'"
+      :title="result.document_title"
+      :text="result.document_slug"
+    />
+    <p v-html="result.highlighted" />
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  result: {
+    type: Object,
+    default: () => {},
+  },
+});
+</script>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -16,13 +16,18 @@
       <Icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
       No results
     </h3>
-    <div v-for="result in results" :key="result.slug" class="search-result">
+    <div
+      v-for="result in results"
+      :key="result.slug"
+      class="search-result mb-8"
+    >
       <!-- Result summary for creatures including mini statblock -->
       <div v-if="result.route == 'monsters/'" class="result-summary">
         <nuxt-link
           tag="a"
           :params="{ id: result.slug }"
           :to="`/${result.route}${result.slug}`"
+          class="font-bold"
         >
           {{ result.name }}
         </nuxt-link>
@@ -37,7 +42,7 @@
         />
         <div>
           <stat-bar
-            class="top-border"
+            class="mt-1 border-t pt-1"
             :stats="{
               str: result.strength,
               dex: result.dexterity,
@@ -56,6 +61,7 @@
           tag="a"
           :params="{ id: result.slug }"
           :to="`/${result.route}${result.slug}`"
+          class="font-bold"
         >
           {{ result.name }}
         </nuxt-link>
@@ -66,7 +72,7 @@
           :title="result.document_title"
           :text="result.document_slug"
         />
-        <p class="result-highlights" v-html="result.highlighted" />
+        <p v-html="result.highlighted" />
       </div>
 
       <!-- Result summary for magic items -->
@@ -75,6 +81,7 @@
           tag="a"
           :params="{ id: result.slug }"
           :to="`/magic-items/${result.slug}`"
+          class="font-bold"
         >
           {{ result.name }}
         </nuxt-link>
@@ -85,7 +92,7 @@
           :title="result.document_title"
           :text="result.document_slug"
         />
-        <p class="result-highlights" v-html="result.highlighted" />
+        <p v-html="result.highlighted" />
       </div>
 
       <!-- Result summary for everything else -->
@@ -94,6 +101,7 @@
           tag="a"
           :params="{ id: result.slug }"
           :to="`/${result.route}${result.slug}`"
+          class="font-bold"
         >
           {{ result.name }}
         </nuxt-link>
@@ -103,7 +111,7 @@
           :title="result.document_title"
           :text="result.document_slug"
         />
-        <p class="result-highlights" v-html="result.highlighted" />
+        <p v-html="result.highlighted" />
       </div>
     </div>
   </section>
@@ -167,36 +175,9 @@ function sortResults(search, results) {
 }
 </script>
 
-<style lang="scss" scoped>
-@import './assets/variables';
-
-.search-result {
-  margin-bottom: 2rem;
-
-  a {
-    font-weight: bold;
-  }
-
-  :deep(.highlighted) {
-    background-color: lightgoldenrodyellow;
-    font-weight: bold;
-  }
-}
-
-.top-border {
-  margin-top: 0.35rem;
-  padding-top: 0.25rem;
-  border-top: 1px solid rgba($color-smoke, 0.5);
-  font-size: 14px;
-  opacity: 0.7;
-}
-
-hr {
-  margin-bottom: 2rem;
-}
-
-.result-highlights {
-  font-size: 14px;
-  opacity: 0.8;
+<style lang="scss">
+.highlighted {
+  background-color: lightgoldenrodyellow;
+  font-weight: bold;
 }
 </style>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -1,6 +1,11 @@
 <template>
   <section class="docs-container container">
-    <h1>Search results</h1>
+    <h1>
+      <span>Search results for </span>
+      <span class="ml-2 font-thin uppercase text-granite before:content-['_']">
+        {{ searchString }}
+      </span>
+    </h1>
     <hr />
     <p v-if="loading" class="font-sans text-3xl font-bold text-slate-400">
       Searching Open5e...
@@ -9,39 +14,44 @@
       <Icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
       <span class="text-3xl font-bold">No results</span>
     </p>
+    <div v-if="results && !loading">
+      <!-- SEARCH RESULTS -->
+      <p class="mb-6 text-xl font-bold tracking-wide text-granite">
+        {{ `${sortedResults.inScope.length} results in your sources ` }}
+      </p>
+      <ul>
+        <li
+          v-for="result in sortedResults.inScope"
+          :key="result.slug"
+          class="search-result mb-8"
+        >
+          <search-preview :result="result" />
+        </li>
+      </ul>
 
-    <!-- SEARCH RESULTS -->
-    <p class="mb-6 text-xl font-bold tracking-wide text-granite">
-      {{ `${sortedResults.inScope.length} results in your sources ` }}
-    </p>
-    <ul v-if="results">
-      <li
-        v-for="result in sortedResults.inScope"
-        :key="result.slug"
-        class="search-result mb-8"
+      <!-- SEARCH RESULTS FROM OTHER SOURCES -->
+      <button
+        v-show="!isOtherSourcesExpanded && sortedResults.outOfScope.length > 0"
+        class="mb-4 text-indigo-600 hover:text-blood hover:underline dark:text-indigo-200 dark:hover:text-red"
+        @click="toggleOtherSources"
       >
-        <search-preview :result="result" />
-      </li>
-    </ul>
-
-    <!-- SEARCH RESULTS FROM OTHER SOURCES -->
-    <button
-      class="mb-6 text-xl font-bold tracking-wide text-granite"
-      @click="toggleOtherSources"
-    >
-      {{
-        `Show ${sortedResults.outOfScope.length} results from other sources `
-      }}
-    </button>
-    <ul v-if="isOtherSourcesExpanded">
-      <li
-        v-for="result in sortedResults.outOfScope"
-        :key="result.slug"
-        class="search-result mb-8"
-      >
-        <search-preview :result="result" />
-      </li>
-    </ul>
+        {{
+          `Show ${sortedResults.outOfScope.length} additional results from other sources `
+        }}
+      </button>
+      <ul v-if="isOtherSourcesExpanded && sortedResults.outOfScope.length > 0">
+        <header class="mb-6 text-xl font-bold tracking-wide text-granite">
+          {{ `${sortedResults.outOfScope.length} results from other sources ` }}
+        </header>
+        <li
+          v-for="result in sortedResults.outOfScope"
+          :key="result.slug"
+          class="search-result mb-8"
+        >
+          <search-preview :result="result" />
+        </li>
+      </ul>
+    </div>
   </section>
 </template>
 
@@ -50,12 +60,16 @@ import { ref, watch, computed } from 'vue';
 import { useMainStore } from '~/store';
 const store = useMainStore();
 const sources = computed(() => store.sourceSelection);
-
 const route = useRoute();
 
-// search state
+// search state - true when data is loading
 const loading = ref(false);
 
+// UI state – controls whether sources from other sources are visible
+const isOtherSourcesExpanded = ref(false);
+const toggleOtherSources = () => {
+  isOtherSourcesExpanded.value = !isOtherSourcesExpanded.value;
+};
 // get initial values from query params & API
 const searchString = ref(route.query.text);
 const results = ref(await getSearchResults(searchString.value));
@@ -63,12 +77,7 @@ const sortedResults = computed(() =>
   sortResults(sources.value, results.value, searchString.value)
 );
 
-const isOtherSourcesExpanded = ref(false);
-const toggleOtherSources = () => {
-  isOtherSourcesExpanded.value = !isOtherSourcesExpanded.value;
-};
-
-// Watch the query param. Run search again if it changes
+// Watch the query param, re-reun search if it ever changes
 watch(
   () => route.query.text,
   async (newQuery) => {
@@ -77,7 +86,7 @@ watch(
   }
 );
 
-// Watch the results. Re-sort them when they change
+// Watch the results, and re-sort them thi
 watch(
   () => [results],
   async (newResults) => {
@@ -98,6 +107,7 @@ async function getSearchResults(query) {
   const { apiUrl } = useRuntimeConfig().public;
   const endpoint = `${apiUrl}/search/?text=${query}`;
   const response = await $fetch(endpoint);
+  isOtherSourcesExpanded.value = false;
   loading.value = false;
   return response.results;
 }
@@ -121,11 +131,13 @@ function splitResultsBySource(sources = [], results) {
       outOfScope.push(result);
     }
   });
-  return {
-    inScope,
-    outOfScope,
-  };
+  return { inScope, outOfScope };
 }
+
+/* sorts the results as follows:
+ * 1st: results whose title begin with the query text
+ * 2nd: results whose title contains the query text
+ * 3rd: results everything else */
 
 function sortByRelevance(query, results) {
   const term = query.toUpperCase();

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -10,14 +10,14 @@
     <p v-if="loading" class="font-sans text-3xl font-bold text-slate-400">
       Searching Open5e...
     </p>
-    <p v-else-if="results.length === 0" class="text-slate-400">
+    <p v-else-if="results?.length === 0" class="text-slate-400">
       <Icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
       <span class="text-3xl font-bold">No results</span>
     </p>
     <div v-if="results && !loading">
       <!-- SEARCH RESULTS -->
       <p class="mb-6 text-xl font-bold tracking-wide text-granite">
-        {{ `${sortedResults.inScope.length} results in your sources ` }}
+        {{ `${sortedResults.inScope?.length} results in your sources ` }}
       </p>
       <ul>
         <li
@@ -31,17 +31,19 @@
 
       <!-- SEARCH RESULTS FROM OTHER SOURCES -->
       <button
-        v-show="!isOtherSourcesExpanded && sortedResults.outOfScope.length > 0"
+        v-show="!isOtherSourcesExpanded && sortedResults.outOfScope?.length > 0"
         class="mb-4 text-indigo-600 hover:text-blood hover:underline dark:text-indigo-200 dark:hover:text-red"
         @click="toggleOtherSources"
       >
         {{
-          `Show ${sortedResults.outOfScope.length} additional results from other sources `
+          `Show ${sortedResults.outOfScope?.length} additional results from other sources `
         }}
       </button>
-      <ul v-if="isOtherSourcesExpanded && sortedResults.outOfScope.length > 0">
+      <ul v-if="isOtherSourcesExpanded && sortedResults.outOfScope?.length > 0">
         <header class="mb-6 text-xl font-bold tracking-wide text-granite">
-          {{ `${sortedResults.outOfScope.length} results from other sources ` }}
+          {{
+            `${sortedResults.outOfScope?.length} results from other sources `
+          }}
         </header>
         <li
           v-for="result in sortedResults.outOfScope"

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -2,61 +2,50 @@
   <section class="docs-container container">
     <h1>Search results</h1>
     <hr />
-    <h3 v-if="loading" class="font-sans font-bold text-slate-400">
+    <p v-if="loading" class="font-sans text-3xl font-bold text-slate-400">
       Searching Open5e...
-    </h3>
-    <h3 v-else-if="noValue" class="font-sans font-bold text-slate-400">
-      <Icon name="majesticons:search-line" class="mr-2 h-8 w-8" />
-      Search for something to see results...
-    </h3>
-    <h3
-      v-else-if="results.length == 0"
-      class="font-sans font-bold text-slate-400"
-    >
+    </p>
+    <p v-else-if="results.length === 0" class="text-slate-400">
       <Icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
-      No results
-    </h3>
-    <div
-      v-for="result in results"
-      :key="result.slug"
-      class="search-result mb-8"
-    >
-      <!-- Result summary for creatures including mini statblock -->
-      <div v-if="result.route == 'monsters/'" class="result-summary">
-        <nuxt-link
-          tag="a"
-          :params="{ id: result.slug }"
-          :to="`/${result.route}${result.slug}`"
-          class="font-bold"
-        >
-          {{ result.name }}
-        </nuxt-link>
-        <span> CR{{ result.challenge_rating }} </span>
-        <span class="title-case">{{ result.type }} | </span>
-        <em>{{ result.hit_points }}hp, AC {{ result.armor_class }}</em>
-        <source-tag
-          v-if="result.document_slug !== 'wotc-srd'"
-          class="source-tag"
-          :title="result.document_title"
-          :text="result.document_slug"
-        />
-        <div>
-          <stat-bar
-            class="mt-1 border-t pt-1"
-            :stats="{
-              str: result.strength,
-              dex: result.dexterity,
-              con: result.constitution,
-              int: result.intelligence,
-              wis: result.wisdom,
-              cha: result.charisma,
-            }"
-          />
-        </div>
-      </div>
+      <span class="text-3xl font-bold">No results</span>
+    </p>
 
-      <!-- Result summary for spells including basic spell info -->
-      <div v-else-if="result.route == 'spells/'" class="result-summary">
+    <!-- SEARCH RESULTS -->
+    <ul v-for="result in results" :key="result.slug" class="search-result mb-8">
+      <!-- Monster summary includes mini statblock -->
+      <li v-if="result.route == 'monsters/'">
+        <p>
+          <nuxt-link
+            tag="a"
+            :params="{ id: result.slug }"
+            :to="`/${result.route}${result.slug}`"
+            class="font-bold"
+          >
+            {{ result.name }}
+          </nuxt-link>
+          <span>{{ ` CR ${result.challenge_rating} | ` }} </span>
+          <em>{{ `${result.hit_points}hp, AC ${result.armor_class}` }}</em>
+          <source-tag
+            v-if="result.document_slug !== 'wotc-srd'"
+            :title="result.document_title"
+            :text="result.document_slug"
+          />
+        </p>
+        <stat-bar
+          class="mt-1 block border-t pt-1"
+          :stats="{
+            str: result.strength,
+            dex: result.dexterity,
+            con: result.constitution,
+            int: result.intelligence,
+            wis: result.wisdom,
+            cha: result.charisma,
+          }"
+        />
+      </li>
+
+      <!-- Spells including basic spell info -->
+      <li v-else-if="result.route == 'spells/'">
         <nuxt-link
           tag="a"
           :params="{ id: result.slug }"
@@ -65,18 +54,17 @@
         >
           {{ result.name }}
         </nuxt-link>
-        {{ result.level }} {{ result.school }} spell | {{ result.dnd_class }}
+        {{ `${result.school} spell | ${result.dnd_class}` }}
         <source-tag
           v-if="result.document_slug !== 'wotc-srd'"
-          class="source-tag"
           :title="result.document_title"
           :text="result.document_slug"
         />
         <p v-html="result.highlighted" />
-      </div>
+      </li>
 
       <!-- Result summary for magic items -->
-      <div v-else-if="result.route == 'magicitems/'" class="result-summary">
+      <li v-else-if="result.route == 'magicitems/'">
         <nuxt-link
           tag="a"
           :params="{ id: result.slug }"
@@ -85,18 +73,17 @@
         >
           {{ result.name }}
         </nuxt-link>
-        {{ result.type }}, {{ result.rarity }}
+        {{ `${result.type}, ${result.rarity}` }}
         <source-tag
           v-if="result.document_slug !== 'wotc-srd'"
-          class="source-tag"
           :title="result.document_title"
           :text="result.document_slug"
         />
         <p v-html="result.highlighted" />
-      </div>
+      </li>
 
       <!-- Result summary for everything else -->
-      <div v-else class="result-summary">
+      <li v-else>
         <nuxt-link
           tag="a"
           :params="{ id: result.slug }"
@@ -107,13 +94,12 @@
         </nuxt-link>
         <source-tag
           v-if="result.document_slug !== 'wotc-srd'"
-          class="source-tag"
           :title="result.document_title"
           :text="result.document_slug"
         />
         <p v-html="result.highlighted" />
-      </div>
-    </div>
+      </li>
+    </ul>
   </section>
 </template>
 
@@ -123,7 +109,6 @@ const route = useRoute();
 
 // search state
 const loading = ref(false);
-const noValue = ref(false);
 
 // get initial values from query params & API
 const searchString = ref(route.query.text);
@@ -148,7 +133,7 @@ async function getSearchResults(query) {
   const endpoint = `${apiUrl}/search/?text=${query}`;
   const response = await $fetch(endpoint);
   loading.value = false;
-  noValue.value = response.results.length === 0;
+  console.log(response.results);
   return sortResults(query, response.results);
 }
 


### PR DESCRIPTION
This PR closes #408 by scoping searching to the specific sources selected by the user. This was achieved by through filtering the results returned by the API on the frontend, nothing about the call to the API has been changed.

In the example below, you can see that the number of results returned from allowed sources is visible underneath the page title.

<img width="400" alt="Screenshot 2024-03-11 at 10 45 54" src="https://github.com/open5e/open5e/assets/47755775/45ff56ce-78f6-4743-9e4b-3a9684f8eb41">

However, if you run the same query and prune back the sources, you see the following. Notice the prompt at the bottom of the screen. Clicking this will reveal sources returned by the API from sources outside of the user's current selection.

<img width="400" alt="Screenshot 2024-03-11 at 10 47 25" src="https://github.com/open5e/open5e/assets/47755775/e0daea31-974c-4665-be7c-e0cf59959614">

While this PR resolves the initial issue, it does surface several other feature that we might want to implement in the future:

- Filtering search results by type (ie. only show me spells or monsters, etc.)
- Implement filtering via URL params on the backend to reduce response times.
- Add additional return fields to the search API endpoint so that, for example we can display *spell level* or *monster type & size* (ie. large monstrosity) to the search preview cards
