### PR TITLE
Feature: select/deselect all sources buttons

### DIFF
--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -20,7 +20,7 @@
       <fieldset>
         <div class="space-y-3">
           <div
-            v-for="(group, organization) in groupedDocuments"
+            v-for="(group, organization) in allSourcesByPublisher"
             :key="organization"
           >
             <h3 class="mt-2">{{ organization }}</h3>
@@ -32,7 +32,7 @@
               <div class="flex h-6 items-center">
                 <input
                   :id="document.slug"
-                  v-model="selectedSources"
+                  v-model="sourcesFormState"
                   :name="document.slug"
                   type="checkbox"
                   class="h-4 w-4 rounded border-gray-300 text-blue-600 accent-blood focus:ring-blue-600"
@@ -55,14 +55,14 @@
         ref="cancelButtonRef"
         type="button"
         class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
-        @click="closeModal()"
+        @click="close()"
       >
         Cancel
       </button>
       <button
         type="button"
         class="inline-flex w-full justify-center rounded-md bg-blood px-3 py-2 text-sm font-semibold text-white shadow-sm ring-offset-2 hover:ring-2 hover:ring-blood focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 sm:col-start-2"
-        @click="saveSelection()"
+        @click="save()"
       >
         Update
       </button>
@@ -77,51 +77,60 @@ import SourceTag from '~/components/SourceTag.vue';
 export default {
   data() {
     return {
-      selectedSources: [],
+      sourcesFormState: [], // current state of the sources form data
     };
   },
   computed: {
     store() {
       return useMainStore();
     },
+
+    // array of all currently selected sources
     sourceSelection: function () {
       return this.store.sourceSelection;
     },
-    documents: function () {
+
+    // array of all available sources
+    allSources: function () {
       return this.store.documents;
     },
-    groupedDocuments: function () {
-      return this.documents.reduce((grouped, document) => {
-        (grouped[document.organization] =
-          grouped[document.organization] || []).push(document);
+
+    // object of sources arranged by publisher (key: publisher, value: array of sources)
+    allSourcesByPublisher: function () {
+      return this.allSources.reduce((grouped, source) => {
+        (grouped[source.organization] =
+          grouped[source.organization] || []).push(source);
         return grouped;
       }, {});
     },
   },
+
+  // update form state when the source selection is updated
   watch: {
-    'store.sourceSelection': function (newVal) {
-      this.selectedSources = [...newVal];
+    'store.sourceSelection': function (sourcesFromStore) {
+      this.sourcesFormState = [...sourcesFromStore];
     },
   },
+
   created() {
-    this.selectedSources = this.store.sourceSelection;
+    this.sourcesFormState = this.store.sourceSelection;
   },
   methods: {
-    closeModal() {
+    close() {
       this.$emit('close'); // emits a 'close' event to the parent component
       setTimeout(() => {
-        this.selectedSources = this.store.sourceSelection;
+        this.sourcesFormState = this.store.sourceSelection;
       }, 300);
     },
-    saveSelection() {
-      this.store.setSources(this.selectedSources);
-      this.closeModal();
+    save() {
+      this.store.setSources(this.sourcesFormState);
+      this.close();
     },
     selectAll() {
-      this.selectedSources = this.documents.map((source) => source.slug);
+      this.sourcesFormState = this.allSources.map((source) => source.slug);
     },
     deselectAll() {
-      this.selectedSources = [];
+      this.sourcesFormState = [];
     },
   },
 };

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -1,48 +1,54 @@
 <template>
   <ModalDialog>
     <slot>
-      <h2 class="mt-0 border-b-4 border-red-400 pb-2">Select Sources</h2>
-      <div class="mt-2">
-        <fieldset>
-          <legend class="sr-only">Source Selection</legend>
-
-          <div class="space-y-3">
+      <h2
+        class="mb-2 mt-0 flex w-full justify-between border-b-4 border-red-400 pb-2"
+      >
+        Select Sources
+        <span class="text-sm">
+          <button class="mr-1 text-blood hover:text-red" @click="selectAll()">
+            All
+          </button>
+          <button
+            class="ml-1 text-granite hover:text-basalt"
+            @click="deselectAll()"
+          >
+            None
+          </button>
+        </span>
+      </h2>
+      <fieldset>
+        <div class="space-y-3">
+          <div
+            v-for="(group, organization) in groupedDocuments"
+            :key="organization"
+          >
+            <h3 class="mt-2">{{ organization }}</h3>
             <div
-              v-for="(group, organization) in groupedDocuments"
-              :key="organization"
+              v-for="document in group"
+              :key="document.slug"
+              class="relative flex items-start"
             >
-              <h3 class="mt-2">{{ organization }}</h3>
-              <div
-                v-for="document in group"
-                :key="document.slug"
-                class="relative flex items-start"
-              >
-                <div class="flex h-6 items-center">
-                  <input
-                    :id="document.slug"
-                    v-model="selectedSourcesComputed"
-                    :name="document.slug"
-                    type="checkbox"
-                    class="h-4 w-4 rounded border-gray-300 text-blue-600 accent-blood focus:ring-blue-600"
-                    :value="document.slug"
-                  />
-                </div>
-                <div class="ml-3 text-sm leading-6">
-                  <label
-                    :for="document.slug"
-                    class="font-medium text-gray-900"
-                    >{{ document.title }}</label
-                  >
-                  <SourceTag
-                    :title="document.title"
-                    :text="document.slug"
-                  ></SourceTag>
-                </div>
+              <div class="flex h-6 items-center">
+                <input
+                  :id="document.slug"
+                  v-model="selectedSources"
+                  :name="document.slug"
+                  type="checkbox"
+                  class="h-4 w-4 rounded border-gray-300 text-blue-600 accent-blood focus:ring-blue-600"
+                  :value="document.slug"
+                />
+              </div>
+              <div class="ml-3 text-sm leading-6">
+                <label :for="document.slug" class="font-medium text-gray-900">
+                  {{ document.title }}
+                </label>
+                <source-tag :title="document.title" :text="document.slug" />
               </div>
             </div>
           </div>
-        </fieldset>
-      </div>
+        </div>
+      </fieldset>
     </slot>
     <template #actions>
       <button
@@ -72,7 +78,6 @@ export default {
   data() {
     return {
       selectedSources: [],
-      open: false,
     };
   },
   computed: {
@@ -92,14 +97,6 @@ export default {
         return grouped;
       }, {});
     },
-    selectedSourcesComputed: {
-      get: function () {
-        return this.selectedSources;
-      },
-      set: function (newValue) {
-        this.selectedSources = newValue;
-      },
-    },
   },
   watch: {
     'store.sourceSelection': function (newVal) {
@@ -107,7 +104,6 @@ export default {
     },
   },
   created() {
-    this.searchText = this.$route.query.text;
     this.selectedSources = this.store.sourceSelection;
   },
   methods: {
@@ -121,12 +117,12 @@ export default {
       this.store.setSources(this.selectedSources);
       this.closeModal();
     },
+    selectAll() {
+      this.selectedSources = this.documents.map((source) => source.slug);
+    },
+    deselectAll() {
+      this.selectedSources = [];
+    },
   },
 };
-</script>
-
-<script setup>
-import { ref } from 'vue';
-
-const open = ref(true);
 </script>


### PR DESCRIPTION
This PR closes #483 by adding buttons to the `SourcesModal` component for selecting or deselecting all sources.

<img width="659" alt="Screenshot of Open5e sources modal, the show all/none buttons are visible" src="https://github.com/open5e/open5e/assets/47755775/7244e91a-2927-4e21-ae1a-4ec8e5ad8c56">