### PR TITLE
Add dark mode to sources

### DIFF
--- a/components/ModalDialog.vue
+++ b/components/ModalDialog.vue
@@ -30,7 +30,7 @@
             leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
             <DialogPanel
-              class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-2 text-left shadow-xl transition-all sm:my-4 sm:w-full sm:max-w-lg sm:p-6"
+              class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-2 text-left shadow-xl transition-all dark:bg-darkness dark:text-white sm:my-4 sm:w-full sm:max-w-lg sm:p-6"
             >
               <!-- Use unnamed slot to inject modal content -->
               <slot />

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -30,7 +30,7 @@
                 <div class="ml-3 text-sm leading-6">
                   <label
                     :for="document.slug"
-                    class="font-medium text-gray-900"
+                    class="font-medium text-gray-900 dark:text-white"
                     >{{ document.title }}</label
                   >
                   <SourceTag


### PR DESCRIPTION
This PR is for issue #473. It adds dark mode styling to the dialog panel and text of the sources modal to ensure the style stays consistent if the user is in Dark mode. Image below of example. 
![Fix](https://github.com/open5e/open5e/assets/77591479/3d56308a-27ec-497e-8dd2-6bd6ea90178f)
