### PR TITLE
494/bugfix slugify search links

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -265,7 +265,8 @@ export default {
           title: 'Gameplay Mechanics',
           route: '/gameplay-mechanics',
           subroutes: this.store.sections.filter(
-            (page) => page.parent === 'Gameplay Mechanics'
+            (page) =>
+              page.parent === 'Gameplay Mechanics' || page.parent === 'Rules'
           ),
         },
         {

--- a/middleware/redirects.global.js
+++ b/middleware/redirects.global.js
@@ -22,9 +22,14 @@ async function replaceSectionsWithParent(path) {
 
   // fetch section parent & create redirect URL
   const { data } = await useFetch(endpoint);
-  if (data?.value) {
-    return `/${data.value.parent.toLowerCase()}/${slug}`;
+  if (!data?.value) {
+    return;
   }
+  const parent = data.value.parent
+    .toLowerCase()
+    .replace(/\s+/g, '-') // replace spaces in section parent w/ hyphens
+    .replace('rules', 'gameplay-mechanics'); // common inconsistancy in data
+  return `/${parent}/${slug}`;
 }
 
 export default defineNuxtRouteMiddleware((to) => {

--- a/store/index.js
+++ b/store/index.js
@@ -350,7 +350,8 @@ export const useMainStore = defineStore({
     },
     allMechanicsSections: (state) => {
       return state.sections.filter(
-        (section) => section.parent === 'Gameplay Mechanics'
+        (section) =>
+          section.parent === 'Gameplay Mechanics' || section.parent === 'Rules'
       );
     },
     allCombatSections: (state) => {


### PR DESCRIPTION
This PR closes #494 by updating the redirects middleware correctly hyphenating URLs where a `section`'s parent had a name which included a space (ie. 'gameplay-mechanics).

While working on this issue, a related problem was surfaced. Sections on the API might have the parent `Gameplay Mechanics` or `Rules`, with only the former being actually index on a top-level page. This has been fixed by adding the Rules sections to the Gameplay Mechanics sections