### PR TITLE
Fix monster sorting by CR

### DIFF
--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -152,7 +152,7 @@
             >
             <sortable-table-header
               :current-sort-dir="ariaSort.challenge_rating"
-              @sort="(dir) => sort('challenge_rating', dir)"
+              @sort="(dir) => sort('cr', dir)"
               >CR</sortable-table-header
             >
             <sortable-table-header
@@ -369,7 +369,7 @@ const ariaSort = computed(() => {
   return {
     name: getAriaSort('name'),
     type: getAriaSort('type'),
-    challenge_rating: getAriaSort('challenge_rating'),
+    challenge_rating: getAriaSort('cr'),
     size: getAriaSort('size'),
     hit_points: getAriaSort('hit_points'),
   };

--- a/store/index.js
+++ b/store/index.js
@@ -42,6 +42,7 @@ const monsterFields = [
   'slug',
   'name',
   'challenge_rating',
+  'cr',
   'type',
   'size',
   'hit_points',


### PR DESCRIPTION
Challenge rating currently sorts alphabetically, rather than numerically. This fix uses the numeric challenge rating available from the API to correctly sort them. 


The Problem:
![image](https://github.com/open5e/open5e/assets/43607012/f672647c-3a22-409c-b7be-85cee6f7f475)
