### PR TITLE
Bugfix: modal menu dark-mode styles

### DIFF
--- a/components/ModalDialog.vue
+++ b/components/ModalDialog.vue
@@ -37,7 +37,7 @@
 
               <!-- Use 'actions' slot for modal buttons/etc -->
               <div
-                class="mt-5 sm:mt-6 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3"
+                class="mt-5 grid grid-cols-1 gap-2 sm:mt-6 sm:grid-flow-row-dense sm:grid-cols-2"
                 :show="slots.actions"
               >
                 <slot name="actions" />

--- a/components/ReportIssue.vue
+++ b/components/ReportIssue.vue
@@ -66,7 +66,11 @@ const closeModal = () => {
               <label for="type" class="text-lg font-bold">
                 What best describes your issue?
               </label>
-              <select v-model="formData.type" name="type" class="w-full p-2">
+              <select
+                v-model="formData.type"
+                name="type"
+                class="w-full border bg-transparent p-2 dark:bg-basalt"
+              >
                 <option value="page">
                   A page is broken or doesn't load properly
                 </option>
@@ -94,7 +98,7 @@ const closeModal = () => {
                 v-model="formData.description"
                 type="text"
                 name="description"
-                class="block w-full border"
+                class="block w-full border dark:bg-basalt"
               />
             </li>
 
@@ -110,7 +114,7 @@ const closeModal = () => {
                 v-model="formData.reproduction"
                 type="text"
                 name="reproduction"
-                class="block h-16 w-full border"
+                class="block h-16 w-full border dark:bg-basalt"
               />
             </li>
           </ul>
@@ -131,7 +135,7 @@ const closeModal = () => {
       <template #actions>
         <!-- Close without submitting -->
         <button
-          class="mt-3 w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:col-start-1 sm:mt-0"
+          class="mt-3 w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-smoke hover:dark:bg-fog sm:col-start-1 sm:mt-0"
           @click="closeModal()"
         >
           Close

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -22,12 +22,15 @@
                   v-model="selectedSources"
                   :name="document.slug"
                   type="checkbox"
-                  class="h-4 w-4 rounded border-gray-300 text-blue-600 accent-blood focus:ring-blue-600"
+                  class="h-4 w-4 rounded border-gray-300 accent-blood"
                   :value="document.slug"
                 />
               </div>
               <div class="ml-3 text-sm leading-6">
-                <label :for="document.slug" class="font-medium text-gray-900">
+                <label
+                  :for="document.slug"
+                  class="font-medium text-gray-900 dark:text-white"
+                >
                   {{ document.title }}
                 </label>
                 <source-tag :title="document.title" :text="document.slug" />


### PR DESCRIPTION
This PR closes issue #511 by adding additional dark mode Tailwind styles to the `ReportIssue` and `SourcesModal` components

<img width="600" alt="Screenshot 2024-06-17 at 08 06 45" src="https://github.com/open5e/open5e/assets/47755775/cba20693-4b00-4f3c-b188-b7f98b1f6cf7">

<img width="670" alt="Screenshot 2024-06-17 at 08 08 09" src="https://github.com/open5e/open5e/assets/47755775/d0156562-a2d3-4a04-b338-9d4384b52fbd">
