### PR TITLE
Bugfix: adding query parameters to slow API requests

### DIFF
--- a/composables/api.ts
+++ b/composables/api.ts
@@ -86,7 +86,9 @@ export const useSubclass = (className: string, subclass: string) => {
 };
 
 export const useSections = (...categories: string[]) => {
-  const { data: sections, isPending } = useFindMany(API_ENDPOINTS.sections);
+  const { data: sections, isPending } = useFindMany(API_ENDPOINTS.sections, {
+    fields: ['slug', 'name', 'parent'].join(),
+  });
   const filtered_sections = computed(() =>
     sections.value?.filter((section) => categories.includes(section.parent))
   );
@@ -120,11 +122,11 @@ export type MagicItemsFilter = {
   isAttunementRequired?: boolean;
 };
 
-export const useDocuments = () => {
+export const useDocuments = (params: Record<string, any> = {}) => {
   const { findMany } = useAPI();
   return useQuery({
     queryKey: ['findMany', API_ENDPOINTS.documents],
-    queryFn: () => findMany(API_ENDPOINTS.documents, []),
+    queryFn: () => findMany(API_ENDPOINTS.documents, [], params),
   });
 };
 

--- a/composables/magic-items.ts
+++ b/composables/magic-items.ts
@@ -1,4 +1,7 @@
-export const useMagicItems = (filters: MagicItemsFilter = {}) => {
+export const useMagicItems = (
+  filters: MagicItemsFilter = {},
+  queryParams: Record<string, any> = {}
+) => {
   const { findMany } = useAPI();
   const { sources } = useSourcesList();
   const { data } = useQuery({
@@ -6,7 +9,8 @@ export const useMagicItems = (filters: MagicItemsFilter = {}) => {
     queryFn: async () => {
       const magicItems = await findMany(
         API_ENDPOINTS.magicitems,
-        sources.value
+        sources.value,
+        queryParams
       );
       return magicItems;
     },

--- a/composables/monsters.ts
+++ b/composables/monsters.ts
@@ -8,13 +8,17 @@ export type MonsterFilter = {
   type?: string;
 };
 
-export const useAllMonsters = () => {
+export const useAllMonsters = (params: Record<string, any> = {}) => {
   const { findMany } = useAPI();
   const { sources } = useSourcesList();
   return useQuery({
-    queryKey: ['monsters', API_ENDPOINTS.monsters, sources],
+    queryKey: ['monsters', API_ENDPOINTS.monsters, sources, params],
     queryFn: async () => {
-      const monsters = await findMany(API_ENDPOINTS.monsters, sources.value);
+      const monsters = await findMany(
+        API_ENDPOINTS.monsters,
+        sources.value,
+        params
+      );
 
       return monsters;
     },

--- a/composables/spells.ts
+++ b/composables/spells.ts
@@ -1,12 +1,19 @@
 import { groupBy } from '~/functions/groupBy';
 
-export const useSpellsByClass = (charClass: string) => {
+export const useSpellsByClass = (
+  charClass: string,
+  params: Record<string, any>
+) => {
   const { findMany } = useAPI();
   const { sources } = useSourcesList();
   return useQuery({
-    queryKey: ['findMany', API_ENDPOINTS.spells, sources],
+    queryKey: ['findMany', API_ENDPOINTS.spells, sources, params],
     queryFn: async () => {
-      const spells = await findMany(API_ENDPOINTS.spells, sources.value);
+      const spells = await findMany(
+        API_ENDPOINTS.spells,
+        sources.value,
+        params
+      );
       const class_spells = spells
         .filter((spell) => {
           return spell.dnd_class.toLowerCase().includes(charClass);
@@ -14,9 +21,7 @@ export const useSpellsByClass = (charClass: string) => {
         .sort(function (a, b) {
           return a.lvl - b.lvl;
         });
-
       const grouped_spells = groupBy(class_spells, 'level_int');
-
       // label groups by level
       const levels = Object.getOwnPropertyNames(grouped_spells).map((key) => {
         return {
@@ -31,13 +36,17 @@ export const useSpellsByClass = (charClass: string) => {
   });
 };
 
-export const useAllSpells = () => {
+export const useAllSpells = (params: Record<string, any> = {}) => {
   const { findMany } = useAPI();
   const { sources } = useSourcesList();
   return useQuery({
-    queryKey: ['allSpells', API_ENDPOINTS.spells, sources],
+    queryKey: ['allSpells', API_ENDPOINTS.spells, sources, params],
     queryFn: async () => {
-      const spells = await findMany(API_ENDPOINTS.spells, sources.value);
+      const spells = await findMany(
+        API_ENDPOINTS.spells,
+        sources.value,
+        params
+      );
       return spells;
     },
   });

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -192,8 +192,12 @@ const { sources } = useSourcesList();
 
 const no_selected_sources = computed(() => sources.value.length);
 const { data: documents } = useDocuments();
-const { data: classes } = useFindMany(API_ENDPOINTS.classes);
-const { data: races } = useFindMany(API_ENDPOINTS.races);
+const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
+  fields: ['name', 'slug'].join(),
+});
+const { data: races } = useFindMany(API_ENDPOINTS.races, {
+  fields: ['name', 'slug'].join(),
+});
 const { data: combat_sections } = useSections('Combat');
 const { data: equipment_sections } = useSections('Equipment');
 const { data: gameplay_sections } = useSections('Gameplay Mechanics');

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -32,5 +32,7 @@
 
 <script setup>
 import SourceTag from '~/components/SourceTag.vue';
-const { data: backgrounds } = useFindMany(API_ENDPOINTS.backgrounds);
+const { data: backgrounds } = useFindMany(API_ENDPOINTS.backgrounds, {
+  fields: ['name', 'slug', 'document__title', 'document__slug'].join(),
+});
 </script>

--- a/pages/classes/index.vue
+++ b/pages/classes/index.vue
@@ -14,7 +14,9 @@
 </template>
 
 <script setup>
-const { data: classes } = useFindMany(API_ENDPOINTS.classes);
+const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
+  fields: ['name', 'slug', 'document__title', 'document__slug'].join(),
+});
 </script>
 
 <style></style>

--- a/pages/conditions/index.vue
+++ b/pages/conditions/index.vue
@@ -14,7 +14,9 @@
 </template>
 
 <script setup>
-const { data: conditions } = useFindMany(API_ENDPOINTS.conditions);
+const { data: conditions } = useFindMany(API_ENDPOINTS.conditions, {
+  fields: ['name', 'slug', 'document__title', 'document__slug'].join(),
+});
 </script>
 
 <style></style>

--- a/pages/feats/index.vue
+++ b/pages/feats/index.vue
@@ -20,7 +20,9 @@
 </template>
 
 <script setup>
-const { data: feats } = useFindMany(API_ENDPOINTS.feats);
+const { data: feats } = useFindMany(API_ENDPOINTS.feats, {
+  fields: ['name', 'slug', 'document__title', 'document__slug'].join(),
+});
 </script>
 
 <style></style>

--- a/pages/magic-items/index.vue
+++ b/pages/magic-items/index.vue
@@ -63,7 +63,17 @@ const magic_items_filters = ref({
   isAttunementRequired: null,
 });
 
-const { data: magic_items } = useMagicItems(magic_items_filters.value);
+const { data: magic_items } = useMagicItems(magic_items_filters.value, {
+  fields: [
+    'slug',
+    'name',
+    'type',
+    'rarity',
+    'requires_attunement',
+    'document__title',
+    'document__slug',
+  ].join(),
+});
 
 const magic_items_by_letter = computed(() => {
   return (magic_items.value ?? []).reduce((acc, item) => {

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -87,7 +87,7 @@
               />
             </th>
             <td>{{ monster.type }}</td>
-            <td><fraction-renderer :challenge="monster.challenge_rating" /></td>
+            <td><fraction-renderer :challenge="monster.cr" /></td>
             <td>{{ monster.size }}</td>
             <td>{{ monster.hit_points }}</td>
           </tr>
@@ -118,7 +118,9 @@ const filters = ref({
   type: null,
 });
 
-const { data: monsters } = useAllMonsters(filters);
+const { data: monsters } = useAllMonsters({
+  fields: ['slug', 'name', 'cr', 'type', 'size', 'hit_points'].join(),
+});
 const filtered_monsters = computed(() => {
   return monsters.value ? filterMonsters(monsters.value, filters.value) : [];
 });

--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -31,5 +31,7 @@
 </template>
 
 <script setup>
-const { data: races } = useFindMany(API_ENDPOINTS.races);
+const { data: races } = useFindMany(API_ENDPOINTS.races, {
+  fields: ['name', 'slug', 'document__title', 'document__slug'].join(),
+});
 </script>

--- a/pages/spells/by-class/[charclass].vue
+++ b/pages/spells/by-class/[charclass].vue
@@ -30,7 +30,6 @@
         </li>
       </ul>
     </div>
-    <p v-else-if="isLoading">Loading...</p>
   </section>
 </template>
 
@@ -39,7 +38,16 @@ import SourceTag from '~/components/SourceTag.vue';
 
 const charclass = useRoute().params.charclass;
 
-const { data: spellsByLevel } = useSpellsByClass(charclass);
+const { data: spellsByLevel } = useSpellsByClass(charclass, {
+  fields: [
+    'name',
+    'slug',
+    'level_int',
+    'document__slug',
+    'document__title',
+    'dnd_class',
+  ].join(),
+});
 </script>
 
 <style lang="scss" scoped>

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -72,15 +72,7 @@
               {{ spell.components }}
             </td>
             <td class="hide-mobile">
-              <span
-                v-for="(spellclass, index) in spell.spell_lists"
-                :key="spellclass"
-              >
-                <!-- the item in the spell_list list -->
-                <span class="spell_lists">{{ capitalize(spellclass) }}</span>
-                <!-- comma after any item that isn't the last -->
-                <span v-if="index + 1 < spell.spell_lists.length">, </span>
-              </span>
+              {{ spell.dnd_class }}
             </td>
           </tr>
         </tbody>
@@ -111,7 +103,7 @@ const { data } = useAllSpells({
     'school',
     'level_int',
     'components',
-    'spell_lists',
+    'dnd_class',
   ].join(),
 });
 

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -104,7 +104,16 @@
 <script setup>
 import PageNav from '~/components/PageNav.vue';
 import SourceTag from '~/components/SourceTag.vue';
-const { data } = useAllSpells();
+const { data } = useAllSpells({
+  fields: [
+    'name',
+    'slug',
+    'school',
+    'level_int',
+    'components',
+    'dnd_class',
+  ].join(),
+});
 
 const PAGE_SIZE = 50;
 

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -111,7 +111,7 @@ const { data } = useAllSpells({
     'school',
     'level_int',
     'components',
-    'dnd_class',
+    'spell_lists',
   ].join(),
 });
 
@@ -127,6 +127,7 @@ const spellPage = computed(() => {
     return [];
   }
 
+  console.log(data.value);
   return sortByField(
     data.value,
     currentSortProperty.value,


### PR DESCRIPTION
### Bug Description
So of the pages on the Open5e site run very slowly, especially on the top-level for our bigger data sets. With the cache disengaged it was taking *8+ seconds* to fetch the data needed to render the `/monsters` route.

<img width="1407" alt="monsters before copy" src="https://github.com/open5e/open5e/assets/47755775/a8dc2b4c-9d12-4cba-bee0-3784e74a3088">

After looking into the problem, it turns out that this slow response was due to the page requesting the entire payload from the https://api.open5e.com/monsters/ endpoint (8.64 MB of data). Looking at what data the page is actually displaying, it is clear we don't need the entire entry for every monster in the DB. The `/monsters` page only a few fields. (name, slug, CR, type, size and source). Similar ineffeciencies could be found across the site.

### Solution

I was able to optimise many of these API calls by updating several data fetching composables to accept query parameters. This way, the `?fields` param could be easily set on any API call. This has greatly improved site-wide response times.

<img width="1501" alt="monsters after copy" src="https://github.com/open5e/open5e/assets/47755775/81b2499a-3c1e-40f1-9797-66ac72ae9072">

The first part of the solution was to update the composables which handle data fetching (#503) to accept query parameters so that unnecesary return fields could be ommitted using the `?fields=` query param. This was a simple change as the `findMany()` method, which is called inside the `useAllMonsters()` and `useAllSpells()` composables, was already set up to accept query params. It was just a case of declaring a new `param` parameter on the derived composables to pass down to `useFindMany()`.

From `composables/monsters.ts`

```
// OLD VERSION - this was called in the script tag on the /monsters page
const useAllMonsters = () => {
  ...
  return useQuery({
    queryKey: ['monsters', API_ENDPOINTS.monsters, sources],
    queryFn: async() => {
      const monsters = await findMany(API_ENDPOINTS.monsters, sources.value)
      return monsters
    }
}
```

```
// NEW VERSION - 'params' arg contains query parameters for the API request
const useAllMonsters = (params: Record<string, any> = {}) => {
  ...
  return useQuery({
    queryKey: ['monsters', API_ENDPOINTS.monsters, sources, params],
    queryFn: async() => {
      const monsters = await findMany(API_ENDPOINTS.monsters, sources.value, params)
      return monsters
    }
}
```

The next part of the solution involved adding `fields` parameters to API requests where it made sense to omit certain fields of the full API response. For example, the list of monsters on the `/monsters` only requires a few fields from the monsters API endpoint to render the results table (on `staging` the page currently requests all fields). By specifying only the fields the page needed, the JSON payload was reduced to roughly 3% (!!) of its original size. This greatly improved the response time from the server.

From `pages/monsters/index.vue`

```
// OLD - request everything
const { data: monsters } = useAllMonsters();
```

```
// NEW - only requestion fields the page actually uses
const { data: monsters } = useAllMonsters({
  fields: ['slug', 'name', 'cr', 'type', 'size', 'hit_points'].join(),
});
```

Similarly, `/layouts/default.vue` makes several API calls to fetch data to display links on the navigation bar. Many of these were also inefficient, and as the layout was mounted on every page site wide load times suffered. Instead of pulling the full description of every class and its subclasses, all that it needs to know to render the navlinks correctly are the class's name, slug, and source.

### Next Steps
Some of the site load times are still not quite up to snuff, `/monsters`, `/spells` and `/magic-items` would still really benefit from pagination (#508)