### PR TITLE
Bugfix: Slugify links to `/gameplay-mechanics` pages on in search results

### DIFF
--- a/middleware/redirects.global.js
+++ b/middleware/redirects.global.js
@@ -22,9 +22,16 @@ async function replaceSectionsWithParent(path) {
 
   // fetch section parent & create redirect URL
   const { data } = await useFetch(endpoint);
-  if (data?.value) {
-    return `/${data.value.parent.toLowerCase()}/${slug}`;
+  if (!data?.value) {
+    return;
   }
+
+  // slugify section parent
+  const parent = data.value.parent
+    .toLowerCase()
+    .replace(/\s+/g, '-') // replace spaces with hyphens
+    .replace('rules', 'gameplay-mechanics'); // handle common inconsistancy in data-set
+  return `/${parent}/${slug}`;
 }
 
 export default defineNuxtRouteMiddleware((to) => {

--- a/pages/gameplay-mechanics/index.vue
+++ b/pages/gameplay-mechanics/index.vue
@@ -27,5 +27,5 @@
 </template>
 
 <script setup>
-const { data: sections } = useSections('Gameplay Mechanics');
+const { data: sections } = useSections('Gameplay Mechanics', 'Rules');
 </script>


### PR DESCRIPTION
This PR closes #494 by updating the redirecting middleware to correctly slugify the `parent` field of API results from the `/sections` endpoint to correctly handle links to the `/gameplay-mechanics` route from the search page.

This PR supersedes PR #495, which was set up to work with the deprecated Pinia store. It proved quicker to reimplement the changes from `staging` than it was to resolve the extensive merge conflicts. 