### PR TITLE
Bugfix: markdown not rendering (typo in `<mdViewer>`)

### DIFF
--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -1,5 +1,5 @@
 <template ref="el">
-  <VueShowdown
+  <vue-showdown
     ref="mdwrapper"
     :vue-template="true"
     :options="{
@@ -7,7 +7,7 @@
       headerLevelStart: headerLevel,
       vueTemplate: true,
     }"
-    :markdown="mdText"
+    :markdown="text"
     :extensions="extensions"
     :class="inline ? 'markdown-inline' : ''"
   />
@@ -42,7 +42,6 @@ const extensions = computed(() => {
   }
   return list;
 });
-
 </script>
 
 <style>


### PR DESCRIPTION
## Description and Reproduction

This PR fixes a bug in the `<md-viewer>` component introduced in #504. The markdown renderer appears to be toast. This bug can be recreated by checking out the staging branch and visiting the page of any monster, spell, magic item, &c.

The `<md-viewer>` component  take a prop called `text`, which contains the markdown string to render as HTML. This component wraps the `<vue-showdown>` component, which actually does the conversion. The prop is not currently not being passed to the `<vue-showdown>`, which is instead looking for the non-existant `mdText` prop. The result of this is that none of the markdown across the site is functions 😱


`/components/MdViewer.vue` from `staging`
```
<template>  
  <vue-showdown
    :markdown="mdText"  // <- there is no mdText prop
    ...
  />
...
</template>

<script setup>
import { VueShowdown } from 'vue-showdown';
const props = defineProps({
  text: { type: String, default: 'loading...' }, // <- this should be passed instead
  ...
});
```

## Solution
The solution was simple - pass the `text` variable as the markdown prop to the `<vue-showdown>` component.

`/components/MdViewer.vue` from `bugfix/mdViewer-params`
```
<template>  
  <vue-showdown
    :markdown="text" // <- change "mdText" to "text"
    ...
  />
...
</template>

<script setup>
import { VueShowdown } from 'vue-showdown';
const props = defineProps({
  text: { type: String, default: 'loading...' },
  ...
});
```