### PR TITLE
Feature: search scoped to sources

### DIFF
--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -3,22 +3,23 @@
 <template>
   <li class="py-2 text-base">
     <!-- Row title -->
-    <h3 class="mt-1 flex align-middle text-lg">
+    <h3 class="mt-1 flex items-center align-middle text-xl">
       <nuxt-link
         tag="a"
         :to="`${getRoute(result.object_model)}/${result.object_pk}`"
       >
         {{ result.object_name }}
       </nuxt-link>
+      <source-tag :text="result.document.key" :title="result.document.name" />
       <span
-        class="font-sans text-sm uppercase text-granite before:mx-2 before:text-lg before:content-['|']"
+        class="font-sans text-sm uppercase text-granite before:mx-2 before:content-['|']"
       >
         {{ result.object_model.match(/[A-Z][a-z]+/g).join(' ') }}
       </span>
     </h3>
 
     <!-- Row subtitle -->
-    <div class="">
+    <div>
       <span v-if="result.object_model === 'Monster'">
         {{
           `
@@ -39,11 +40,11 @@
     <!-- include snipet if query text is not part of article title -->
     <div
       v-if="!result.object_name.toUpperCase().includes(query.toUpperCase())"
-      class="text-sm italic"
+      class="text-sm italic text-granite"
       v-html="result.highlighted"
     />
     <!-- include article source -->
-    <div class="text-sm text-granite">(from {{ result.document.name }})</div>
+    <div class="text-sm">(from {{ result.document.name }})</div>
   </li>
 </template>
 
@@ -77,6 +78,6 @@ function getRoute(model) {
 
 <style>
 .highlighted {
-  @apply bg-black uppercase text-white dark:bg-white dark:text-black;
+  @apply bg-basalt uppercase text-white dark:bg-white dark:text-black;
 }
 </style>

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -1,0 +1,78 @@
+<!-- SearchResults is designed to take a single row returned by the /search API endpoint and return a list item containing a link to a page -->
+
+<template>
+  <li class="border-b py-2">
+    <!-- Row title -->
+    <h3 class="mt-2 flex align-middle">
+      <nuxt-link
+        tag="a"
+        :to="`${getRoute(result.object_model)}/${result.object_pk}`"
+      >
+        {{ result.object_name }}
+      </nuxt-link>
+      <span
+        class="font-sans text-sm uppercase text-granite before:mx-2 before:text-lg before:content-['|']"
+      >
+        {{ result.object_model }}
+      </span>
+    </h3>
+
+    <!-- Row subtitle -->
+    <div class="">
+      <span v-if="result.object_model === 'Monster'">
+        {{ `CR ${result.object.challenge_rating}` }}
+      </span>
+      <span v-else-if="result.object_model === 'Spell'" class="capitalize">
+        {{ result.object.school }} Spell | {{ result.object.dnd_class }}
+      </span>
+      <span v-else-if="result.object_model === 'MagicItem'" class="capitalize">
+        {{ result.object.type }} | {{ result.object.rarity }}
+      </span>
+      <span class="text-sm text-granite">
+        (from {{ result.document.name }})</span
+      >
+    </div>
+
+    <!-- include snipet if query text is not part of article title -->
+    <div
+      class="text-sm"
+      v-if="!result.object_name.toUpperCase().includes(query.toUpperCase())"
+      v-html="result.highlighted"
+    />
+  </li>
+</template>
+
+<script setup>
+defineProps({
+  query: {
+    type: String,
+    default: '',
+  },
+  result: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const ModelToRoute = {
+  Monster: 'monsters',
+  Spell: 'spells',
+  Race: 'races',
+  Section: 'sections',
+  MagicItem: 'magic-items',
+  Feat: 'feats',
+  Background: 'backgrounds',
+  CharClass: 'classes',
+};
+
+function getRoute(model) {
+  return ModelToRoute[model] ?? 'error';
+}
+</script>
+
+<style>
+.highlighted {
+  text-decoration: underline;
+  text-transform: uppercase;
+}
+</style>

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -1,9 +1,9 @@
 <!-- SearchResults is designed to take a single row returned by the /search API endpoint and return a list item containing a link to a page -->
 
 <template>
-  <li class="border-b py-2">
+  <li class="py-2 text-base">
     <!-- Row title -->
-    <h3 class="mt-2 flex align-middle">
+    <h3 class="mt-1 flex align-middle text-lg">
       <nuxt-link
         tag="a"
         :to="`${getRoute(result.object_model)}/${result.object_pk}`"
@@ -13,32 +13,37 @@
       <span
         class="font-sans text-sm uppercase text-granite before:mx-2 before:text-lg before:content-['|']"
       >
-        {{ result.object_model }}
+        {{ result.object_model.match(/[A-Z][a-z]+/g).join(' ') }}
       </span>
     </h3>
 
     <!-- Row subtitle -->
     <div class="">
       <span v-if="result.object_model === 'Monster'">
-        {{ `CR ${result.object.challenge_rating}` }}
+        {{
+          `
+           CR ${result.object.challenge_rating} | 
+           HP ${result.object.hit_points},
+           AC ${result.object.armor_class}
+           `
+        }}
       </span>
       <span v-else-if="result.object_model === 'Spell'" class="capitalize">
         {{ result.object.school }} Spell | {{ result.object.dnd_class }}
       </span>
       <span v-else-if="result.object_model === 'MagicItem'" class="capitalize">
-        {{ result.object.type }} | {{ result.object.rarity }}
+        {{ result.object.type }}, {{ result.object.rarity }}
       </span>
-      <span class="text-sm text-granite">
-        (from {{ result.document.name }})</span
-      >
     </div>
 
     <!-- include snipet if query text is not part of article title -->
     <div
-      class="text-sm"
       v-if="!result.object_name.toUpperCase().includes(query.toUpperCase())"
+      class="text-sm italic"
       v-html="result.highlighted"
     />
+    <!-- include article source -->
+    <div class="text-sm text-granite">(from {{ result.document.name }})</div>
   </li>
 </template>
 
@@ -72,7 +77,6 @@ function getRoute(model) {
 
 <style>
 .highlighted {
-  text-decoration: underline;
-  text-transform: uppercase;
+  @apply bg-black uppercase text-white dark:bg-white dark:text-black;
 }
 </style>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -2,7 +2,7 @@
   <section class="docs-container container">
     <h1>Search results</h1>
     <hr />
-    <h3 v-if="!search_results" class="font-sans font-bold text-slate-400">
+    <h3 v-if="!results" class="font-sans font-bold text-slate-400">
       Searching Open5e...
     </h3>
     <h3 v-else-if="!searchText" class="font-sans font-bold text-slate-400">
@@ -10,15 +10,15 @@
       Search for something to see results...
     </h3>
     <h3
-      v-if="search_results && search_results.length == 0"
+      v-if="results && results.length === 0"
       class="font-sans font-bold text-slate-400"
     >
       <Icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
       No results
     </h3>
-    <div v-if="search_results">
+    <div v-if="results">
       <div
-        v-for="result in search_results"
+        v-for="result in resultsInScope"
         :key="result.object_pk"
         class="search-result"
       >
@@ -123,6 +123,7 @@
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import StatBar from '~/components/StatBar';
 import SourceTag from '~/components/SourceTag';
 
@@ -142,7 +143,19 @@ function getRoute(model) {
 }
 
 const searchText = useQueryParam('text');
-const { data: search_results } = useSearch(searchText);
+const { data: results } = useSearch(searchText);
+const { sources } = useSourcesList();
+
+const resultsInScope = computed(() => {
+  const [inScope, outScope] = results.value.reduce(
+    ([inScope, outScope], item) =>
+      sources.value.includes(item.document.key)
+        ? [[...inScope, item], outScope]
+        : [inScope, [...outScope, item]],
+    [[], []]
+  );
+  return inScope;
+});
 </script>
 
 <style lang="scss" scoped>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -9,11 +9,11 @@
         <icon name="majesticons:search-line" class="mr-2 h-8 w-8" />
         <span>Search for something to see results...</span>
       </span>
-      <span v-else-if="results.inScope.length > 0">
+      <span v-else-if="results.inScope">
         <icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
         <span>{{ results.inScope.length }} results in your sources</span>
         <span v-if="results.outScope.length > 0" class="font-thin">
-          (and {{ results.outScope.length }} in other sources)
+          ({{ results.outScope.length }} in other sources)
         </span>
       </span>
     </p>
@@ -38,7 +38,8 @@
       </button>
     </div>
 
-    <ul v-if="results && results.inScope.length > 0 && isOtherSourcesExpanded">
+    <!-- Out of scope results (hidden by default) -->
+    <ul v-if="results && results.outScope.length > 0 && isOtherSourcesExpanded">
       <search-result
         v-for="item in results.outScope"
         :key="item.object_pk"
@@ -61,6 +62,7 @@ const results = computed(() => {
   if (!data || !data.value) {
     return;
   }
+  // split result based on which from currently selected sources
   const [inScope, outScope] = data.value.reduce(
     ([inScope, outScope], item) =>
       sources.value.includes(item.document.key)
@@ -71,6 +73,7 @@ const results = computed(() => {
   return { inScope, outScope };
 });
 
+// state for expanding results from other sources
 const isOtherSourcesExpanded = ref(false);
 const toggleOtherSources = () => {
   isOtherSourcesExpanded.value = !isOtherSourcesExpanded.value;

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -2,7 +2,8 @@
   <section class="docs-container container">
     <h1>Search</h1>
     <hr class="mb-8" />
-    <p class="mb-6 font-sans font-bold text-slate-400">
+    <!-- Header -->
+    <p class="font-sans text-xl font-bold text-slate-400">
       <span v-if="!data" class="h-8">Searching Open5e...</span>
       <span v-else-if="!searchText">
         <icon name="majesticons:search-line" class="mr-2 h-8 w-8" />
@@ -11,9 +12,13 @@
       <span v-else-if="results.inScope.length > 0">
         <icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
         <span>{{ results.inScope.length }} results in your sources</span>
+        <span v-if="results.outScope.length > 0" class="font-thin">
+          (and {{ results.outScope.length }} in other sources)
+        </span>
       </span>
     </p>
 
+    <!-- Result list -->
     <ul v-if="results && results.inScope.length > 0">
       <search-result
         v-for="item in results.inScope"
@@ -23,11 +28,24 @@
       />
     </ul>
 
-    <div v-if="results && results.outScope.length > 0">
-      <button class="text-mana">
-        Show {{ results.outScope.length }} results from other sources
+    <div v-if="results && results.outScope.length > 0" class="my-2 border-t">
+      <button
+        class="mt-2 font-sans text-xl font-bold tracking-wide text-indigo-600 hover:text-blood hover:underline dark:text-indigo-200 dark:hover:text-red"
+        @click="toggleOtherSources()"
+      >
+        {{ isOtherSourcesExpanded ? `Showing ` : `Show ` }}
+        {{ results.outScope.length }} results from other sources
       </button>
     </div>
+
+    <ul v-if="results && results.inScope.length > 0 && isOtherSourcesExpanded">
+      <search-result
+        v-for="item in results.outScope"
+        :key="item.object_pk"
+        :result="item"
+        :query="searchText"
+      />
+    </ul>
   </section>
 </template>
 
@@ -52,30 +70,9 @@ const results = computed(() => {
   );
   return { inScope, outScope };
 });
+
+const isOtherSourcesExpanded = ref(false);
+const toggleOtherSources = () => {
+  isOtherSourcesExpanded.value = !isOtherSourcesExpanded.value;
+};
 </script>
-
-<style lang="scss" scoped>
-@import './assets/variables';
-
-.search-result {
-  margin-bottom: 2rem;
-
-  a {
-    font-weight: bold;
-  }
-
-  :deep(.highlighted) {
-    background-color: lightgoldenrodyellow;
-    font-weight: bold;
-  }
-}
-
-hr {
-  margin-bottom: 2rem;
-}
-
-.result-highlights {
-  font-size: 14px;
-  opacity: 0.8;
-}
-</style>

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -1,160 +1,56 @@
 <template>
   <section class="docs-container container">
-    <h1>Search results</h1>
-    <hr />
-    <h3 v-if="!results" class="font-sans font-bold text-slate-400">
-      Searching Open5e...
-    </h3>
-    <h3 v-else-if="!searchText" class="font-sans font-bold text-slate-400">
-      <Icon name="majesticons:search-line" class="mr-2 h-8 w-8" />
-      Search for something to see results...
-    </h3>
-    <h3
-      v-if="results && results.length === 0"
-      class="font-sans font-bold text-slate-400"
-    >
-      <Icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
-      No results
-    </h3>
-    <div v-if="results">
-      <div
-        v-for="result in resultsInScope"
-        :key="result.object_pk"
-        class="search-result"
-      >
-        <!-- Result summary for creatures including mini statblock -->
-        <div v-if="result.object_model == 'Monster'" class="result-summary">
-          <nuxt-link
-            tag="a"
-            :params="{ id: result.object_pk }"
-            :to="`/monsters/${result.object_pk}`"
-          >
-            {{ result.object_name }}
-          </nuxt-link>
-          <span> CR{{ result.object.challenge_rating }} </span
-          ><span class="title-case">{{ result.type }} | </span>
-          <em
-            >{{ result.object.hit_points }}hp, AC
-            {{ result.object.armor_class }}</em
-          >
-          <source-tag
-            v-if="result.document.key !== 'wotc-srd'"
-            class="source-tag"
-            :title="result.document.name"
-            :text="result.document.key"
-          />
-          <div>
-            <stat-bar
-              class="top-border"
-              :stats="{
-                str: result.object.strength,
-                dex: result.object.dexterity,
-                con: result.object.constitution,
-                int: result.object.intelligence,
-                wis: result.object.wisdom,
-                cha: result.object.charisma,
-              }"
-            />
-          </div>
-        </div>
+    <h1>Search</h1>
+    <hr class="mb-8" />
+    <p class="mb-6 font-sans font-bold text-slate-400">
+      <span v-if="!data" class="h-8">Searching Open5e...</span>
+      <span v-else-if="!searchText">
+        <icon name="majesticons:search-line" class="mr-2 h-8 w-8" />
+        <span>Search for something to see results...</span>
+      </span>
+      <span v-else-if="results.inScope.length > 0">
+        <icon name="majesticons:scroll-line" class="mr-2 h-8 w-8" />
+        <span>{{ results.inScope.length }} results in your sources</span>
+      </span>
+    </p>
 
-        <!-- Result summary for spells including basic spell info -->
-        <div v-else-if="result.object_model == 'Spell'" class="result-summary">
-          <nuxt-link
-            tag="a"
-            :params="{ id: result.object_pk }"
-            :to="`/spells/${result.object_pk}`"
-          >
-            {{ result.object_name }}
-          </nuxt-link>
-          {{ result.object.level }} {{ result.object.school }} spell |
-          {{ result.object.dnd_class }}
-          <source-tag
-            v-if="result.document.key !== 'wotc-srd'"
-            class="source-tag"
-            :title="result.document.name"
-            :text="result.document.key"
-          />
-          <p class="result-highlights" v-html="result.highlighted" />
-        </div>
+    <ul v-if="results && results.inScope.length > 0">
+      <search-result
+        v-for="item in results.inScope"
+        :key="item.object_pk"
+        :result="item"
+        :query="searchText"
+      />
+    </ul>
 
-        <!-- Result summary for magic items -->
-        <div
-          v-else-if="result.object_model == 'MagicItem'"
-          class="result-summary"
-        >
-          <nuxt-link
-            tag="a"
-            :params="{ id: result.object_pk }"
-            :to="`/magic-items/${result.object_pk}`"
-          >
-            {{ result.object_name }}
-          </nuxt-link>
-          {{ result.object.type }}, {{ result.object.rarity }}
-          <source-tag
-            v-if="result.document.key !== 'wotc-srd'"
-            class="source-tag"
-            :title="result.document.name"
-            :text="result.document.key"
-          />
-          <p class="result-highlights" v-html="result.highlighted" />
-        </div>
-
-        <!-- Result summary for everything else -->
-        <div v-else class="result-summary">
-          <nuxt-link
-            tag="a"
-            :params="{ id: result.object_pk }"
-            :to="`/${getRoute(result.object_model)}/${result.object_pk}`"
-          >
-            {{ result.object_name }}
-          </nuxt-link>
-          <source-tag
-            v-if="result.document.key !== 'wotc-srd'"
-            class="source-tag"
-            :title="result.document.name"
-            :text="result.document.key"
-          />
-          <p class="result-highlights" v-html="result.highlighted" />
-        </div>
-      </div>
+    <div v-if="results && results.outScope.length > 0">
+      <button class="text-mana">
+        Show {{ results.outScope.length }} results from other sources
+      </button>
     </div>
   </section>
 </template>
 
 <script setup>
 import { computed } from 'vue';
-import StatBar from '~/components/StatBar';
-import SourceTag from '~/components/SourceTag';
-
-const ModelToRoute = {
-  Monster: 'monsters',
-  Spell: 'spells',
-  Race: 'races',
-  Section: 'sections',
-  MagicItem: 'magic-items',
-  Feat: 'feats',
-  Background: 'backgrounds',
-  CharClass: 'classes',
-};
-
-function getRoute(model) {
-  return ModelToRoute[model] ?? 'error';
-}
+import SearchResult from '~/components/SearchResult';
 
 const searchText = useQueryParam('text');
-const { data: results } = useSearch(searchText);
+const { data } = useSearch(searchText);
 const { sources } = useSourcesList();
 
-const resultsInScope = computed(() => {
-  const [inScope, outScope] = results.value.reduce(
+const results = computed(() => {
+  if (!data || !data.value) {
+    return;
+  }
+  const [inScope, outScope] = data.value.reduce(
     ([inScope, outScope], item) =>
       sources.value.includes(item.document.key)
         ? [[...inScope, item], outScope]
         : [inScope, [...outScope, item]],
     [[], []]
   );
-  return inScope;
+  return { inScope, outScope };
 });
 </script>
 
@@ -172,14 +68,6 @@ const resultsInScope = computed(() => {
     background-color: lightgoldenrodyellow;
     font-weight: bold;
   }
-}
-
-.top-border {
-  margin-top: 0.35rem;
-  padding-top: 0.25rem;
-  border-top: 1px solid rgba($color-smoke, 0.5);
-  font-size: 14px;
-  opacity: 0.7;
 }
 
 hr {


### PR DESCRIPTION
This PR closes #408 by applying by filtering to search results based on the current sources that the user has selected. Results from other sources can be viewed by clicking a button at the bottom of the `/search` page.

The filtering by source currently takes place on the front end, in the script tag for `/pages/search/index.vue` page component.

### Demonstration 
With all sources selected you might see something like this:
<img width="600" alt="Screenshot 2024-06-27 at 09 34 16" src="https://github.com/open5e/open5e/assets/47755775/c63bfcd1-03c3-49f2-a185-7d5d5bc72f5d">

Here is what the search page looks like if your search is returning only a few results due to your sources (NB. the highlighted snippet returned by the API is only rendered if the search term is not included in the article's title)

<img width="600" alt="Screenshot 2024-06-27 at 09 35 05" src="https://github.com/open5e/open5e/assets/47755775/ac25d251-ed55-4a8f-84e1-6d0291b1a587">

Clicking on the view results from other sources button exposes a second list:
<img width="600" alt="Screenshot 2024-06-27 at 09 35 14" src="https://github.com/open5e/open5e/assets/47755775/2572a386-1095-4ca1-ad4b-3c0155b456b2">

### Closing Thoughts
There are a few vector to futher optimisation to the `/search` page that spring to mind. These were not pursued in this PR as they would have required making changes to our data fetching infrastructure, putting them somewhat out of the scope of this PR.

- Currently, in scope and out of scope results are all fetched on page load and filtered on the front end. It would be more efficient to only fetch the in scope results on page load and only fetch the out of scope results when needed.
- Server-side pagination could speed up load times (see issue #508)

