### PR TITLE
Feature: publisher filters in `<SourcesModal>`

### DIFF
--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -1,6 +1,7 @@
 <template>
   <modal-dialog>
     <slot>
+      <!-- Modal menu title bar -->
       <div class="flex w-full justify-between border-b-4 border-red-400">
         <h2 class="mt-0 pb-2">Select Sources</h2>
         <div class="serif font-bold">
@@ -18,49 +19,70 @@
           </button>
         </div>
       </div>
-      <div class="mt-2">
-        <fieldset>
-          <legend class="sr-only">Source Selection</legend>
-          <div
-            v-for="(publications, organization, index) in groupedDocuments"
-            :key="index"
-            class="space-y-1"
-          >
-            <h3 class="mt-1 inline-block">{{ organization }}</h3>
+
+      <fieldset class="mt-1">
+        <legend class="sr-only">Source Selection</legend>
+        <!-- Organisation -->
+        <div
+          v-for="(publications, organization, index) in groupedDocuments"
+          :key="index"
+          class="space-y-0"
+        >
+          <!-- Organisation Title -->
+          <div class="my-1 flex items-center gap-2">
+            <h3 class="mt-0 inline-block items-center gap-2">
+              {{ organization }}
+            </h3>
             <button
-              class="ml-2 inline px-2 font-sans font-bold text-blood hover:text-red-800 dark:hover:text-red-400"
+              :class="
+                selectedSourcesByPublisher(organization)
+                  ? 'border-none bg-blood'
+                  : 'border-2 bg-white'
+              "
+              class="size-5 rounded-sm border-gray-500 text-sm font-bold text-white"
               @click="togglePublisher(organization)"
             >
-              All
+              <span
+                v-if="selectedSourcesByPublisher(organization)"
+                class="not-sr-only"
+              >
+                &#10003;
+              </span>
+              <span class="sr-only">
+                {{
+                  selectedSourcesByPublisher(organization)
+                    ? `include sources from ${organization}`
+                    : `exclude sources from ${organization}`
+                }}
+              </span>
             </button>
-            <div
-              v-for="document in publications"
-              :key="document.slug"
-              class="relative flex items-start"
-            >
-              <div class="flex h-6 items-center">
-                <input
-                  :id="document.slug"
-                  v-model="selectedSources"
-                  :name="document.slug"
-                  type="checkbox"
-                  class="h-4 w-4 rounded border-gray-300 text-blue-600 accent-blood focus:ring-blue-600"
-                  :value="document.slug"
-                />
-              </div>
-              <div class="ml-3 text-sm leading-6">
-                <label
-                  :for="document.slug"
-                  class="font-medium text-gray-900 dark:text-white"
-                >
-                  {{ document.title }}
-                </label>
-                <source-tag :title="document.title" :text="document.slug" />
-              </div>
-            </div>
           </div>
-        </fieldset>
-      </div>
+
+          <!-- Sources by Organisation -->
+          <ul
+            v-for="document in publications"
+            :key="document.slug"
+            class="relative flex items-start"
+          >
+            <li>
+              <input
+                v-model="selectedSources"
+                :name="document.slug"
+                type="checkbox"
+                class="mr-2 mt-1 h-4 w-4 rounded text-blue-600 accent-blood focus:ring-blue-600"
+                :value="document.slug"
+              />
+              <label
+                :for="document.slug"
+                class="font-medium text-gray-900 dark:text-white"
+              >
+                {{ document.title }}
+              </label>
+              <source-tag :title="document.title" :text="document.slug" />
+            </li>
+          </ul>
+        </div>
+      </fieldset>
     </slot>
     <template #actions>
       <button
@@ -112,7 +134,7 @@ function togglePublisher(publisher) {
     (source) => source.slug // get slugs for sources by publisher
   );
 
-  if (isPublisherSelected(publisher)) {
+  if (selectedSourcesByPublisher(publisher)) {
     selectedSources.value = selectedSources.value.filter(
       (source) => !sourcesByPublisher.includes(source)
     );
@@ -124,7 +146,7 @@ function togglePublisher(publisher) {
   }
 }
 
-function isPublisherSelected(publisher) {
+function selectedSourcesByPublisher(publisher) {
   // find all sources for this publisher
   const allSources = groupedDocuments.value[publisher].map(
     (source) => source.slug
@@ -133,7 +155,7 @@ function isPublisherSelected(publisher) {
   const currentSources = selectedSources.value.filter((source) =>
     allSources.includes(source)
   );
-  return allSources.length === currentSources.length;
+  return currentSources.length;
 }
 
 function selectAll() {

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -26,7 +26,13 @@
             :key="index"
             class="space-y-1"
           >
-            <h3 class="mt-2">{{ organization }}</h3>
+            <h3 class="mt-1 inline-block">{{ organization }}</h3>
+            <button
+              class="ml-2 inline px-2 font-sans font-bold text-blood hover:text-red-800 dark:hover:text-red-400"
+              @click="togglePublisher(organization)"
+            >
+              All
+            </button>
             <div
               v-for="document in publications"
               :key="document.slug"
@@ -94,12 +100,18 @@ const groupedDocuments = computed(() => {
 });
 
 function closeModal() {
-  console.log(groupedDocuments);
   emit('close'); // emits a 'close' event to the parent component
 }
 function saveSelection() {
   setSources(selectedSources.value);
   closeModal();
+}
+
+function togglePublisher(publisher) {
+  const sourcesToAdd = groupedDocuments.value[publisher]
+    .map((source) => source.slug) // get source slugs from sources for a publisher
+    .filter((source) => !selectedSources.value.includes(source)); // find unchecked sources
+  selectedSources.value = [...selectedSources.value, ...sourcesToAdd]; // combine checked & unchecked sources
 }
 
 function selectAll() {

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -108,10 +108,32 @@ function saveSelection() {
 }
 
 function togglePublisher(publisher) {
-  const sourcesToAdd = groupedDocuments.value[publisher]
-    .map((source) => source.slug) // get source slugs from sources for a publisher
-    .filter((source) => !selectedSources.value.includes(source)); // find unchecked sources
-  selectedSources.value = [...selectedSources.value, ...sourcesToAdd]; // combine checked & unchecked sources
+  const sourcesByPublisher = groupedDocuments.value[publisher].map(
+    (source) => source.slug // get slugs for sources by publisher
+  );
+
+  if (isPublisherSelected(publisher)) {
+    selectedSources.value = selectedSources.value.filter(
+      (source) => !sourcesByPublisher.includes(source)
+    );
+  } else {
+    const sourcesToAdd = sourcesByPublisher.filter(
+      (source) => !selectedSources.value.includes(source)
+    );
+    selectedSources.value = [...selectedSources.value, ...sourcesToAdd]; // combine checked & unchecked sources
+  }
+}
+
+function isPublisherSelected(publisher) {
+  // find all sources for this publisher
+  const allSources = groupedDocuments.value[publisher].map(
+    (source) => source.slug
+  );
+  // find which of these are part of the current selected sources
+  const currentSources = selectedSources.value.filter((source) =>
+    allSources.includes(source)
+  );
+  return allSources.length === currentSources.length;
 }
 
 function selectAll() {


### PR DESCRIPTION
This PR closes #486 by adding additional buttons to the right of publisher names in the `<sources-modal>` component which select/deselect all sources by that publisher.

All other features of the sources modal function as previously

### Light Mode

<img width="300" alt="Screenshot 2024-07-01 at 15 26 24" src="https://github.com/open5e/open5e/assets/47755775/95a7ea97-7bd4-47a5-b228-0b33f2d58931">
<img width="290" alt="Screenshot 2024-07-01 at 15 26 55" src="https://github.com/open5e/open5e/assets/47755775/0485682d-2e42-4090-bfbd-ac32cefc52cc">


### Dark Mode
<img width="300" alt="Screenshot 2024-07-01 at 15 26 32" src="https://github.com/open5e/open5e/assets/47755775/0d053564-0916-4bae-8d39-e674143b704f">

<img width="300" alt="Screenshot 2024-07-01 at 15 26 47" src="https://github.com/open5e/open5e/assets/47755775/1392a267-3580-46ad-8fa1-66f1f9aa8a00">
