### PR TITLE
UI: Dice Roller enchancements

### DIFF
--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -1,8 +1,13 @@
 <template>
   <div class="absolute bottom-0 right-8 m-0 flex flex-col-reverse p-0">
-    <div v-if="notifications.length" class="flex gap-2">
-      <h2 class="my-0">Notifications</h2>
-      <button @click="clear()">Clear</button>
+    <div
+      v-if="notifications.length"
+      class="flex gap-2 bg-white/80 dark:bg-darkness/80"
+    >
+      <h2 class="my-0 text-lg">Notifications</h2>
+      <button class="font-bold text-blood hover:text-red-400" @click="clear()">
+        Clear
+      </button>
     </div>
     <ul class="flex flex-col">
       <li
@@ -10,13 +15,21 @@
         :key="index"
         class="mt-1 border-b-2 border-t-2 border-red-400 bg-gray-100 px-3 py-2 dark:bg-slate-900"
       >
-        <span class="text-xl font-bold">{{ notification }}</span>
-        <button
-          class="float-right font-bold text-blood transition-all hover:text-red-400"
-          @click="remove(index)"
-        >
-          &#x2715;
-        </button>
+        <p class="my-0 font-serif text-xs font-light">
+          {{ notification.title }}
+        </p>
+        <div class="my-0 flex justify-between align-middle font-bold">
+          <p class="m-0 text-4xl">{{ notification.body }}</p>
+          <button
+            class="float-right font-bold text-blood transition-all hover:text-red-400"
+            @click="remove(index)"
+          >
+            &#x2715;
+          </button>
+        </div>
+        <div class="m-0 p-0 text-sm">
+          {{ notification.footer }}
+        </div>
       </li>
     </ul>
   </div>

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="absolute bottom-0 right-8 m-0 flex flex-col-reverse p-0">
+    <div v-if="notifications.length" class="flex gap-2">
+      <h2 class="my-0">Notifications</h2>
+      <button @click="clear()">Clear</button>
+    </div>
+    <ul class="flex flex-col">
+      <li
+        v-for="(notification, index) in notifications"
+        :key="index"
+        class="mt-1 border-b-2 border-t-2 border-red-400 bg-gray-100 px-3 py-2 dark:bg-slate-900"
+      >
+        <span class="text-xl font-bold">{{ notification }}</span>
+        <button
+          class="float-right font-bold text-blood transition-all hover:text-red-400"
+          @click="remove(index)"
+        >
+          &#x2715;
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { useNotifications } from '~/composables/useNotifications';
+const { clear, notifications, remove } = useNotifications();
+</script>

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -25,4 +25,11 @@
 <script setup>
 import { useNotifications } from '~/composables/useNotifications';
 const { clear, notifications, remove } = useNotifications();
+
+// clear notifications when route changes
+const route = useRoute();
+watch(
+  () => route.path,
+  () => clear()
+);
 </script>

--- a/components/StatBar.vue
+++ b/components/StatBar.vue
@@ -4,10 +4,12 @@
       v-for="(stat, key) in stats"
       :key="key"
       class="mr-4 flex flex-col items-center"
-      @click="useDiceRoller(useFormatModifier(stat, 'score'))"
+      @click="useDiceRoller(useFormatModifier(stat, { inputType: 'score' }))"
     >
       <span class="font-bold capitalize">{{ key }}</span>
-      <span>{{ stat }} ({{ useFormatModifier(stat, 'score') }}) </span>
+      <span>
+        {{ stat }} ({{ useFormatModifier(stat, { inputType: 'score' }) }})
+      </span>
     </li>
   </ul>
 </template>

--- a/composables/useDicerRoller.ts
+++ b/composables/useDicerRoller.ts
@@ -1,7 +1,9 @@
+import { useNotifications } from './useNotifications';
+const { notifications, addNotif } = useNotifications();
+
 export function useDiceRoller(signature: string) {
   // extract numerical data from dice signature
   const parsed = parseDice(signature);
-
   // make sure parseDice rtn'd data before deconstructing arr.
   if (!parsed) {
     return;
@@ -15,7 +17,10 @@ export function useDiceRoller(signature: string) {
 
   // add up the results and add the modifier
   const result = rolls.reduce((total, roll) => total + roll) + modifier;
-  alert(result);
+
+  // push results to notifications
+  addNotif(`${result} [${rolls.map((roll) => roll)}] + ${modifier}`);
+
   return { signature, rolls, result };
 }
 

--- a/composables/useDicerRoller.ts
+++ b/composables/useDicerRoller.ts
@@ -1,5 +1,5 @@
 import { useNotifications } from './useNotifications';
-const { notifications, addNotif } = useNotifications();
+const { addNotif } = useNotifications();
 
 export function useDiceRoller(signature: string) {
   // extract numerical data from dice signature
@@ -18,8 +18,16 @@ export function useDiceRoller(signature: string) {
   // add up the results and add the modifier
   const result = rolls.reduce((total, roll) => total + roll) + modifier;
 
+  const formattedModifier = useFormatModifier(modifier, {
+    showZero: false,
+  });
+
   // push results to notifications
-  addNotif(`${result} [${rolls.map((roll) => roll)}] + ${modifier}`);
+  addNotif({
+    title: `Rolling ${number}d${dice} ${formattedModifier}`,
+    body: result,
+    footer: `[ ${rolls.join(', ')} ] ${formattedModifier}`,
+  });
 
   return { signature, rolls, result };
 }

--- a/composables/useFormatModifier.ts
+++ b/composables/useFormatModifier.ts
@@ -1,9 +1,22 @@
 export const useFormatModifier = (
   input: string | number,
-  inputType?: 'modifier' | 'score'
+  options?: {
+    inputType?: 'modifier' | 'score';
+    showZero: boolean;
+  }
 ) => {
-  const type = inputType ?? 'modifer';
+  // set options defaults
+  const type = options?.inputType ?? 'modifer';
+  const showZero = options?.showZero ?? true;
+
+  // cast input to number
   const inputNum = typeof input === 'string' ? parseInt(input) : input;
+
+  // handle 0s is showZero option is false
+  if (inputNum === 0 && !showZero) return '';
+
+  // convert score to mod
   const mod = type === 'score' ? Math.floor((inputNum - 10) / 2) : inputNum;
-  return (mod < 0 ? '' : '+') + mod.toString();
+
+  return (mod < 0 ? '- ' : '+ ') + mod.toString().replace('-', '');
 };

--- a/composables/useNotifications.js
+++ b/composables/useNotifications.js
@@ -1,0 +1,19 @@
+import { ref } from 'vue';
+
+const notifications = ref([]);
+
+export const useNotifications = () => {
+  const addNotif = (notif) => {
+    notifications.value.push(notif);
+  };
+
+  const clear = () => {
+    notifications.value = [];
+  };
+
+  const remove = (index) => {
+    notifications.value.splice(index, 1);
+  };
+
+  return { clear, remove, notifications, addNotif };
+};

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -105,6 +105,8 @@
           @click="hideSidebar"
         />
 
+        <page-notifications />
+
         <!-- Main page content -->
         <nuxt-page
           class="main-content pt-auto mx-0 w-full px-4 py-4 pb-0 text-darkness dark:text-white sm:px-8"


### PR DESCRIPTION
This PR closes #526 by adding a more attractive method displaying results generated by the Open5e Dice Roller. 

<img width="240" alt="Screenshot 2024-07-17 at 18 10 38" src="https://github.com/user-attachments/assets/95f1c72f-5a98-494a-9c93-3e45add792cb">
<img width="240" alt="Screenshot 2024-07-17 at 18 10 45" src="https://github.com/user-attachments/assets/fa8ba6a9-1fb3-4399-97fb-ee27f5e232c3">

Previously dice roll results generated by the `useDiceRoller` composable were displayed to users via the `alert` function. In this iteration they are displayed as notification originated from the bottom-right of the screen. Displaying these notifications is handled by the new `PageNotifications` component.

As the dice rollers and layout are remote from each other in DOM done, emitting a custom event from the dice roller to update the notifications was not an options. Instead the `useNotifications` composable was created. This composable essentially as a singleton that stores notifications across components. It could conceivably be used for display other kinds of data in the future should we wish.

Care has been taken to match the light and dark mode styles already in use across the website, but there remains lots of scope to improve these notifications visually. Adding entrance and exit animations to the `PageNotification` component is an obvious next step.