### PR TITLE
Bugfix: `SourcesModal` now closes on away-click or ESC key

### DIFF
--- a/components/ModalDialog.vue
+++ b/components/ModalDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <TransitionRoot as="template" :show="open">
+  <TransitionRoot as="template" :show="open" @key.escape="closeModal">
     <Dialog as="div" class="relative z-100" @close="closeModal">
       <TransitionChild
         as="template"
@@ -11,7 +11,7 @@
         leave-to="opacity-0"
       >
         <div
-          class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          class="fixed inset-0 bg-gray-500/75 transition-opacity"
           @close="closeModal()"
         />
       </TransitionChild>
@@ -70,6 +70,7 @@ const props = defineProps({
 const emits = defineEmits(['close', 'update:open']);
 
 const closeModal = () => {
+  emits('close', true);
   emits('update:open', false);
 };
 </script>

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <modal-dialog>
+  <modal-dialog @close="closeModal()">
     <slot>
       <!-- Modal menu title bar -->
       <div class="flex w-full justify-between border-b-4 border-red-400">


### PR DESCRIPTION
This PR closes #516 by adding additional ways to close the `<source-modal>` component which should improve user-experience when interacting with this feature.

Previously, the source modal could only be closed by clicking either of the call to action buttons at the bottom. Now it can also be closed by:

1) Clicking away from the modal menu (there was code in situ that looks like it once handled this, but the events were not being emitted correctly)

2) Pressing the ESCAPE key

