### PR TITLE
Bugfix: `SourcesModal` light-mode styles

### DIFF
--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -1,7 +1,7 @@
 <template>
   <modal-dialog>
     <slot>
-      <!-- Modal menu title bar -->
+      <!-- MODAL MENU TITLE BAR -->
       <div class="flex w-full justify-between border-b-4 border-red-400">
         <h2 class="mt-0 pb-2">Select Sources</h2>
         <div class="serif font-bold">
@@ -9,12 +9,11 @@
             :class="`px-2 py-1 ${
               // toggle styles based on selected sources
               allSourcesSelected()
-                ? ' text-black dark:text-white'
-                : ' text-blood hover:text-red-800 dark:hover:text-red-400'
+                ? ` text-black before:mr-1 before:content-['✓'] dark:text-white`
+                : ` text-blood hover:text-red-800 dark:hover:text-red-400`
             }`"
             @click="selectAll()"
           >
-            <span v-if="allSourcesSelected()">&#10003; </span>
             <span>All</span>
           </button>
 
@@ -22,17 +21,17 @@
             :class="`px-2 py-1 ${
               // toggle styles based on selected sources
               selectedSources.length === 0
-                ? ' text-black dark:text-white'
-                : ' text-blood hover:text-red-800 dark:hover:text-red-400'
+                ? ` text-black before:mr-1 before:content-['✓'] dark:text-white`
+                : ` text-blood hover:text-red-800 dark:hover:text-red-400 `
             }`"
             @click="deselectAll()"
           >
-            <span v-if="selectedSources.length === 0">&#10003; </span>
             <span>None</span>
           </button>
         </div>
       </div>
 
+      <!-- MODAL MENU BODY -->
       <fieldset class="mt-1">
         <legend class="sr-only">Source Selection</legend>
         <!-- Organisation -->
@@ -45,39 +44,29 @@
             <h3 class="mt-0 inline-block items-center gap-2">
               {{ organization }}
             </h3>
-            <!-- Add all sources for this publisher -->
-            <a
-              v-if="
+            <!-- Button for adding all src by publisher to selected srcs -->
+            <button
+              :class="`px-2 py-1 font-bold  ${
                 selectedSourcesByPublisher(organization) ===
                 countSourcesByPublisher(organization)
-              "
-              class="cursor-default px-2 py-1 font-bold text-white"
-            >
-              &#10003; All
-            </a>
-            <a
-              v-else
-              class="dark:hover:text-red-4000 px-2 py-1 text-blood hover:text-red-800"
-              href="#"
-              @click.prevent="addPublisher(organization)"
+                  ? `before:mr-1 before:content-['✓']`
+                  : `text-blood hover:text-red-800 dark:hover:text-red-400`
+              }`"
+              @click="addPublisher(organization)"
             >
               All
-            </a>
-            <!-- Remove all sources for this publisher -->
-            <a
-              v-if="!selectedSourcesByPublisher(organization)"
-              class="cursor-default px-2 py-1 font-bold text-white"
-            >
-              &#10003; None
-            </a>
-            <a
-              v-else
-              class="px-2 py-1 text-blood hover:text-red-800 dark:hover:text-red-400"
-              href="#"
-              @click.prevent="removePublisher(organization)"
+            </button>
+            <!-- Button for removing all srcs by publisher to selected srcs -->
+            <button
+              :class="`0 px-2 py-1 font-bold ${
+                !selectedSourcesByPublisher(organization)
+                  ? `before:mr-1 before:content-['✓']`
+                  : `dark:hover:text-red-40 text-blood hover:text-red-800`
+              }`"
+              @click="removePublisher(organization)"
             >
               None
-            </a>
+            </button>
           </div>
 
           <!-- Sources by Organisation -->

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -6,32 +6,29 @@
         <h2 class="mt-0 pb-2">Select Sources</h2>
         <div class="serif font-bold">
           <button
-            v-if="selectedSources.length == documents.length"
-            class="cursor-default px-2 py-1 font-bold text-white"
-          >
-            &#10003; All
-          </button>
-
-          <button
-            v-else
-            class="px-2 py-1 text-blood hover:text-red-800 dark:hover:text-red-400"
+            :class="`px-2 py-1 ${
+              // toggle styles based on selected sources
+              allSourcesSelected()
+                ? ' text-black dark:text-white'
+                : ' text-blood hover:text-red-800 dark:hover:text-red-400'
+            }`"
             @click="selectAll()"
           >
-            All
+            <span v-if="allSourcesSelected()">&#10003; </span>
+            <span>All</span>
           </button>
 
           <button
-            v-if="selectedSources.length === 0"
-            class="cursor-default px-2 py-1 font-bold text-white"
-          >
-            &#10003; None
-          </button>
-          <button
-            v-else
-            class="px-2 py-1 text-blood hover:text-red-800 dark:hover:text-red-400"
+            :class="`px-2 py-1 ${
+              // toggle styles based on selected sources
+              selectedSources.length === 0
+                ? ' text-black dark:text-white'
+                : ' text-blood hover:text-red-800 dark:hover:text-red-400'
+            }`"
             @click="deselectAll()"
           >
-            None
+            <span v-if="selectedSources.length === 0">&#10003; </span>
+            <span>None</span>
           </button>
         </div>
       </div>
@@ -206,6 +203,10 @@ function selectedSourcesByPublisher(publisher) {
     allSources.includes(source)
   );
   return currentSources.length;
+}
+
+function allSourcesSelected() {
+  return selectedSources.value.length === documents.value.length;
 }
 
 function selectAll() {


### PR DESCRIPTION
Closes #535 by updating the Tailwind styles of the `<sources-modal>` component to fix white text being displayed againt a white background in the ALL / NONE source selector UI.


<img width="503" alt="Screenshot 2024-07-19 at 10 08 32" src="https://github.com/user-attachments/assets/555d472d-f257-47fd-9b55-a95d9c5f2607">

<img width="500" alt="Screenshot 2024-07-19 at 10 08 40" src="https://github.com/user-attachments/assets/51c3084a-6640-426c-b21d-74e55025ce37">

Dark mode styles look the same as previously:

<img width="486" alt="Screenshot 2024-07-18 at 09 23 41" src="https://github.com/user-attachments/assets/680deae3-23e2-440b-b911-1eabe77ebe16">

While I was here I took the chance to do a little house-cleaning (i couldn't help myself) and refactored the code used to conditionally generate ticks using the Tailwind `before:content-[]` selector. This streamlines the template considerably and should improve code readability going forward