### PR TITLE
Bugfix: Wrap `higher_level` fields on `/spells/[id]` in Markdown renderer

### DIFF
--- a/pages/spells/[id].vue
+++ b/pages/spells/[id].vue
@@ -33,7 +33,7 @@
     <md-viewer :text="spell.desc" :use-roller="true" />
     <p v-if="spell.higher_level">
       <label class="font-bold">At higher levels:</label>
-      {{ spell.higher_level }}
+      <md-viewer :text="spell.higher_level" />
     </p>
     <p class="text-sm italic">
       Source:


### PR DESCRIPTION
This PR closes #537 by wrapping the `higher_level` field returned by the API in the `<md-viewer>` component.