### PR TITLE
Update search endpoint and formatting

### DIFF
--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -10,12 +10,10 @@
       >
         {{ result.object_name }}
       </nuxt-link>
-      <source-tag :text="result.document.key" :title="result.document.name" />
-      <span
-        class="font-sans text-sm uppercase text-granite before:mx-2 before:content-['|']"
-      >
+      <span class="ml-2 font-sans text-sm uppercase text-granite">
         {{ result.object_model.match(/[A-Z][a-z]+/g).join(' ') }}
       </span>
+      <source-tag :text="result.document.key" :title="result.document.name" />
     </h3>
 
     <!-- Row subtitle -->
@@ -38,10 +36,10 @@
     </div>
 
     <!-- include snipet if query text is not part of article title -->
-    <div
+    <md-viewer
       v-if="!result.object_name.toUpperCase().includes(query.toUpperCase())"
-      class="text-sm italic text-granite"
-      v-html="result.highlighted"
+      class="text-sm italic text-basalt dark:text-granite"
+      :markdown="stripMarkdownTables(result.highlighted)"
     />
     <!-- include article source -->
     <div class="text-sm">(from {{ result.document.name }})</div>
@@ -71,6 +69,14 @@ const ModelToRoute = {
   CharClass: 'classes',
 };
 
+function stripMarkdownTables(text) {
+  // Remove table row markup but keep the content
+  return text
+    .replace(/\|/g, ' ') // Replace pipe characters with spaces
+    .replace(/(\r\n|\n|\r)/gm, ' ') // Remove line breaks
+    .replace(/-{3,}/g, ''); // Remove three or more hyphens
+}
+
 function getRoute(model) {
   return ModelToRoute[model] ?? 'error';
 }
@@ -78,6 +84,6 @@ function getRoute(model) {
 
 <style>
 .highlighted {
-  @apply bg-basalt uppercase text-white dark:bg-white dark:text-black;
+  @apply bg-amber-300 px-1 text-black dark:bg-yellow-800 dark:text-white;
 }
 </style>

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -11,7 +11,7 @@ export const API_ENDPOINTS = {
   magicitems: 'v1/magicitems',
   monsters: 'v1/monsters',
   races: 'v1/races',
-  search: 'v2/search',
+  search: 'v2/search/',
   sections: 'v1/sections',
   spells: 'v1/spells',
 } as const;


### PR DESCRIPTION
This update adds a trailing slash to the search endpoint definition, to avoid a 301 error (identified by @augustjohnson) with the new v2 endpoints

It also cleans up the display of search previews by:
- switching to a yellow highlight instead of a gray one
- making the snippet dark enough to pass accessibility checks
- removing markdown table formatting (pipes and 3+ dashes in a row) from preview snippets
- rendering the snippets as markdown (to include bold or other useful formatting)
  - this also requires stripping newlines from the snippet, which has been done
  

Before:
  
<img width="733" alt="image" src="https://github.com/user-attachments/assets/a37e22c5-7719-401d-a3e6-cd4c6389e674">

<img width="701" alt="image" src="https://github.com/user-attachments/assets/eadbc401-6887-465c-aea5-ce9dd18e009b">

   
After:

<img width="709" alt="image" src="https://github.com/user-attachments/assets/fd627e16-5155-4197-b3af-42e0e23f20a2">

<img width="689" alt="image" src="https://github.com/user-attachments/assets/e8bb80b1-f218-4c50-b8b4-3315651e6dfb">
