### PR TITLE
539 Bug: trailing comma in monsters without alignment

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -31,7 +31,7 @@
         {{
           `${monster.size} ${monster.type}${
             monster.subtype ? ` (${monster.subtype})` : ''
-          } ${monster.alignment ? `, ${monster.alignment}` : ''}`
+          }${monster.alignment ? `, ${monster.alignment}` : ''}`
         }}
       </span>
       <source-tag

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -31,7 +31,7 @@
         {{
           `${monster.size} ${monster.type}${
             monster.subtype ? ` (${monster.subtype})` : ''
-          }, ${monster.alignment}`
+          } ${monster.alignment ? `, ${monster.alignment}` : ''}`
         }}
       </span>
       <source-tag

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -27,12 +27,15 @@
       class="img-main"
     />
     <p class="italic">
-      <span>
-        {{
-          `${monster.size} ${monster.type}${
-            monster.subtype ? ` (${monster.subtype})` : ''
-          }${monster.alignment ? `, ${monster.alignment}` : ''}`
-        }}
+      <span>{{ `${monster.size} ${monster.type}` }}</span>
+      <span
+        v-if="monster.subtype"
+        class="before:content-['_('] after:content-[')']"
+      >
+        {{ monster.subtype }}
+      </span>
+      <span v-if="monster.alignment" class="before:content-[',_']">
+        {{ monster.alignment }}
       </span>
       <source-tag
         v-show="monster.document__slug"


### PR DESCRIPTION
https://github.com/open5e/open5e/issues/539

Without alignment: 
<img width="496" alt="image" src="https://github.com/user-attachments/assets/e8dcaca1-4be8-49cc-917c-c2501c8d474f">

With alignment:
<img width="541" alt="image" src="https://github.com/user-attachments/assets/da239816-cf57-4647-90d7-d873e93e00c3">

