### PR TITLE
mobile: ensure sidebar minimizes upon route change

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -185,9 +185,12 @@ const title = computed(() => {
 useHead({ title: title });
 const searchText = ref($route.query.text);
 
-watch($route, () => {
-  showSidebar.value = false;
-});
+watch(
+  () => $route.path,
+  () => {
+    showSidebar.value = false;
+  }
+);
 
 const showModal = ref(false);
 const { sources } = useSourcesList();


### PR DESCRIPTION
This PR addresses issue #551, where the sidebar was not minimizing correctly upon route changes.

In `layouts/default.vue` there was a watcher component that wasn't working as expected:

```javascript
watch($route, () => {
  showSidebar.value = false;
});
```

It was modified to:

```javascript
watch(
  () => $route.path,
  () => {
    showSidebar.value = false;
  }
);
```

Please review the changes and let me know if further adjustments are needed.

https://github.com/user-attachments/assets/0e480a6e-981f-45d3-aba2-ed114f095ab0

This PR will close issue #551 

