### PR TITLE
Bugfix: dark mode hover colors for inline dice roller

### DIFF
--- a/components/InlineRoller.global.vue
+++ b/components/InlineRoller.global.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    class="cursor-pointer font-bold text-blood hover:text-black"
+    class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
     @click="useDiceRoller(signature)"
   >
     <slot />

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -55,7 +55,7 @@
           <span class="font-bold after:content-['_']">Hit Points</span>
           <span class="after:content-['_']">{{ monster.hit_points }}</span>
           <span
-            class="cursor-pointer font-bold text-blood hover:text-black"
+            class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
             @click="useDiceRoller(monster.hit_dice)"
           >
             {{ `(${monster.hit_dice})` }}
@@ -88,7 +88,7 @@
           <span class="block font-bold uppercase">{{ ability.shortName }}</span>
           <span class="after:content-['_']">{{ ability.score }}</span>
           <span
-            class="cursor-pointer font-bold text-blood hover:text-black"
+            class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
             @click="useDiceRoller(ability.modifier)"
           >
             {{ `(${ability.modifier})` }}


### PR DESCRIPTION
## The Problem

Open5e's dice roller links change colour when hovered over. This looks good in light mode, where the red links turn black:

<img width="350" alt="Screenshot 2024-08-16 at 22 10 33" src="https://github.com/user-attachments/assets/ffeab811-4f5b-4410-95b4-4508e083afda">
<img width="350" alt="Screenshot 2024-08-16 at 22 10 40" src="https://github.com/user-attachments/assets/4575436d-7d39-47c6-aa87-a471381eaea4">



This, however, looks rubbish on dark mode where the same hover style is used. Leaving us with black text on a black background:

<img width="350" alt="Screenshot 2024-08-16 at 22 10 47" src="https://github.com/user-attachments/assets/92091d77-4b4b-4b0e-b56a-5dc5f2520e3e">

<img width="350" alt="Screenshot 2024-08-16 at 22 10 53" src="https://github.com/user-attachments/assets/6422b8fb-760a-4a16-b282-bbe30e8e15c5">

## The Solution

Added dark mode hover state using Tailwind pseudo selectors to any dice signature used by the `useDiceRoller()` composable.

<img width="437" alt="Screenshot 2024-08-16 at 22 15 48" src="https://github.com/user-attachments/assets/fa5916d3-aa45-4eed-91dd-a032196be803">


