### PR TITLE
Bugfix: disable SRI on dynamic routes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,7 +69,7 @@ export default defineNuxtConfig({
      * (Cloudflare throwing a SRI error on dynamic routes) */
     '/*/**': {
       security: {
-        sri: true,
+        sri: false,
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -62,6 +62,18 @@ export default defineNuxtConfig({
   router: {
     prefetchLinks: false,
   },
+
+  routeRules: {
+    /* Turn off SRI for dynamic routes, leave it on for top-level pages
+     * NB. this is a work-around & doens't resolve the underlying issue
+     * (Cloudflare throwing a SRI error on dynamic routes) */
+    '/*/**': {
+      security: {
+        sri: true,
+      },
+    },
+  },
+
   hooks: {
     'vite:extendConfig': (config, { isClient, isServer }) => {
       if (isClient) {
@@ -73,4 +85,5 @@ export default defineNuxtConfig({
     configPath: '~/tailwind.config.ts',
     cssPath: '~/styles/tailwind.css',
   },
+  compatibilityDate: '2024-08-15',
 });


### PR DESCRIPTION
This PR should act as a work around for a bug which many user have reported where navigating to a dynamic route (ie. `/classes/bard` or `/monsters/goblin`) throws an SRI error. As this bug is likely due to a weird interaction with Cloudflare it is not really possible to thoroughly test this PR on local, but the test server and build process appear to work without issue.

NB. this PR does not fix the bug, but it should mean that the website is still usable while we investigate solutions for this error.