### PR TITLE
Documents V2

### DIFF
--- a/components/ApiResultRow.vue
+++ b/components/ApiResultRow.vue
@@ -4,8 +4,8 @@
       <!-- Row header contains a link to article and a source tag -->
       <nuxt-link
         tag="a"
-        :params="{ id: data.slug }"
-        :to="`/${endpoint}/${data.slug}`"
+        :params="{ id: slug }"
+        :to="`/${endpoint}/${slug}`"
         :prefetch="false"
       >
         {{ data.name }}
@@ -35,6 +35,9 @@ const props = defineProps({
   // An arr. of which fields in the data prop to render as columns
   cols: { type: Array, default: () => [] },
 });
+
+// Result UID has a different btwn API V1 & V2 - handle both 'key' & 'slug'
+const slug = props.data.key ?? props.data.slug;
 
 const format = (input) => {
   // parse decimals <1 as fractions

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -27,7 +27,7 @@
       <tbody v-if="results && results.length > 0">
         <api-result-row
           v-for="item in results"
-          :key="item.slug"
+          :key="item.key ?? item.slug"
           :data="item"
           :endpoint="endpoint"
           :cols="cols"
@@ -86,7 +86,7 @@ const { data, pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
     isSortDescending: isSortDescending,
     filter: filter,
     params: {
-      fields: ['slug', 'name'].concat(props.cols).join(),
+      fields: ['key', 'slug', 'name'].concat(props.cols).join(),
     },
   });
 

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -128,7 +128,9 @@ const { sources, setSources } = useSourcesList();
 const emit = defineEmits(['close']);
 
 const selectedSources = ref(sources.value);
-const { data: documents } = useDocuments();
+const { data: documents } = useDocuments({
+  fields: ['key', 'name', 'publisher', 'ruleset'].join(','),
+});
 
 const groupedDocuments = computed(() => {
   const docs = documents.value ?? [];

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -30,7 +30,6 @@
           </button>
         </div>
       </div>
-
       <!-- MODAL MENU BODY -->
       <fieldset class="mt-1">
         <legend class="sr-only">Source Selection</legend>
@@ -75,21 +74,29 @@
             :key="document.key"
             class="relative flex items-start"
           >
-            <li>
-              <input
-                v-model="selectedSources"
-                :name="document.key"
-                type="checkbox"
-                class="mr-2 mt-1 h-4 w-4 rounded text-blue-600 accent-blood focus:ring-blue-600"
-                :value="document.key"
-              />
-              <label
-                :for="document.key"
-                class="font-medium text-gray-900 dark:text-white"
+            <li class="flex w-full justify-between">
+              <div>
+                <input
+                  v-model="selectedSources"
+                  :name="document.key"
+                  type="checkbox"
+                  class="mr-2 mt-1 h-4 w-4 rounded text-blue-600 accent-blood focus:ring-blue-600"
+                  :value="document.key"
+                />
+                <label
+                  :for="document.key"
+                  class="font-medium text-gray-900 dark:text-white"
+                >
+                  {{ document.name }}
+                </label>
+                <source-tag :title="document.name" :text="document.key" />
+              </div>
+              <span
+                v-if="document.ruleset"
+                class="h-min rounded-xl bg-fog px-2 text-xs dark:bg-slate-800"
               >
-                {{ document.name }}
-              </label>
-              <source-tag :title="document.name" :text="document.key" />
+                {{ document.ruleset.name }}
+              </span>
             </li>
           </ul>
         </div>
@@ -126,9 +133,8 @@ const { data: documents } = useDocuments();
 const groupedDocuments = computed(() => {
   const docs = documents.value ?? [];
   return docs.reduce((grouped, document) => {
-    (grouped[document.publisher] = grouped[document.publisher] || []).push(
-      document
-    );
+    (grouped[document.publisher.name] =
+      grouped[document.publisher.name] || []).push(document);
     return grouped;
   }, {});
 });

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -72,24 +72,24 @@
           <!-- Sources by Organisation -->
           <ul
             v-for="document in publications"
-            :key="document.slug"
+            :key="document.key"
             class="relative flex items-start"
           >
             <li>
               <input
                 v-model="selectedSources"
-                :name="document.slug"
+                :name="document.key"
                 type="checkbox"
                 class="mr-2 mt-1 h-4 w-4 rounded text-blue-600 accent-blood focus:ring-blue-600"
-                :value="document.slug"
+                :value="document.key"
               />
               <label
-                :for="document.slug"
+                :for="document.key"
                 class="font-medium text-gray-900 dark:text-white"
               >
-                {{ document.title }}
+                {{ document.name }}
               </label>
-              <source-tag :title="document.title" :text="document.slug" />
+              <source-tag :title="document.name" :text="document.key" />
             </li>
           </ul>
         </div>
@@ -126,8 +126,9 @@ const { data: documents } = useDocuments();
 const groupedDocuments = computed(() => {
   const docs = documents.value ?? [];
   return docs.reduce((grouped, document) => {
-    (grouped[document.organization] =
-      grouped[document.organization] || []).push(document);
+    (grouped[document.publisher] = grouped[document.publisher] || []).push(
+      document
+    );
     return grouped;
   }, {});
 });
@@ -142,7 +143,7 @@ function saveSelection() {
 
 function addPublisher(publisher) {
   const sourcesByPublisher = groupedDocuments.value[publisher].map(
-    (source) => source.slug
+    (source) => source.key
   );
 
   const sourcesToAdd = sourcesByPublisher.filter(
@@ -153,7 +154,7 @@ function addPublisher(publisher) {
 
 function removePublisher(publisher) {
   const sourcesByPublisher = groupedDocuments.value[publisher].map(
-    (source) => source.slug
+    (source) => source.key
   );
 
   selectedSources.value = selectedSources.value.filter(
@@ -163,7 +164,7 @@ function removePublisher(publisher) {
 
 function togglePublisher(publisher) {
   const sourcesByPublisher = groupedDocuments.value[publisher].map(
-    (source) => source.slug // get slugs for sources by publisher
+    (source) => source.key // get slugs for sources by publisher
   );
 
   if (selectedSourcesByPublisher(publisher)) {
@@ -185,7 +186,7 @@ function countSourcesByPublisher(publisher) {
 function selectedSourcesByPublisher(publisher) {
   // find all sources for this publisher
   const allSources = groupedDocuments.value[publisher].map(
-    (source) => source.slug
+    (source) => source.key
   );
   // find which of these are part of the current selected sources
   const currentSources = selectedSources.value.filter((source) =>
@@ -199,7 +200,7 @@ function allSourcesSelected() {
 }
 
 function selectAll() {
-  selectedSources.value = documents.value.map((doc) => doc.slug);
+  selectedSources.value = documents.value.map((doc) => doc.key);
 }
 
 function deselectAll() {

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -96,6 +96,8 @@ export const useFindMany = (
   params?: MaybeRef<Record<string, string | number>>
 ) => {
   const { findMany } = useAPI();
+
+  // API V1 & V2 use different PKs for sources. Select the correct one.
   const { sources, sourcesAPIVersion1 } = useSourcesList();
   const sourcesForAPIVersion = isV1Endpoint(unref(endpoint))
     ? sourcesAPIVersion1
@@ -288,6 +290,6 @@ export const useSearch = (queryRef: Ref<string>) => {
 export const useQueryParam = (paramName: string) =>
   computed(() => useRoute().query[paramName]);
 
-function isV1Endpoint(endpoint: string) {
+export function isV1Endpoint(endpoint: string) {
   return endpoint.includes('v1/');
 }

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -266,6 +266,7 @@ export type MagicItemsFilter = {
 };
 
 export const useDocuments = (params: Record<string, any> = {}) => {
+  params.depth = '1';
   const { findMany } = useAPI();
   return useQuery({
     queryKey: ['findMany', API_ENDPOINTS.documents],

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -96,11 +96,17 @@ export const useFindMany = (
   params?: MaybeRef<Record<string, string | number>>
 ) => {
   const { findMany } = useAPI();
-  const { sources } = useSourcesList();
+  const { sources, sourcesAPIVersion1 } = useSourcesList();
+  const sourcesForAPIVersion = isV1Endpoint(unref(endpoint))
+    ? sourcesAPIVersion1
+    : sources;
+
   return useQuery({
-    queryKey: ['findMany', endpoint, sources, params],
+    queryKey: ['findMany', endpoint, sourcesForAPIVersion, params],
     queryFn: () =>
-      unref(findMany(unref(endpoint), unref(sources), unref(params))),
+      unref(
+        findMany(unref(endpoint), unref(sourcesForAPIVersion), unref(params))
+      ),
   });
 };
 
@@ -124,12 +130,16 @@ export const useFindPaginated = (options: {
   } = options;
   const pageNo = ref(unref(initialPage));
   const { findPaginated } = useAPI();
-  const { sources } = useSourcesList();
+  const { sources, sourcesAPIVersion1 } = useSourcesList();
+  const sourcesForAPIVersion = isV1Endpoint(unref(endpoint))
+    ? sourcesAPIVersion1
+    : sources;
+
   const { data, isFetching, error } = useQuery({
     queryKey: [
       'findPaginated',
       endpoint,
-      sources,
+      sourcesForAPIVersion,
       itemsPerPage,
       pageNo,
       sortByProperty,
@@ -141,7 +151,7 @@ export const useFindPaginated = (options: {
     queryFn: () =>
       findPaginated({
         endpoint: unref(endpoint),
-        sources: unref(sources),
+        sources: unref(sourcesForAPIVersion),
         pageNo: unref(pageNo),
         sortByProperty: unref(sortByProperty),
         isSortDescending: unref(isSortDescending),
@@ -277,3 +287,7 @@ export const useSearch = (queryRef: Ref<string>) => {
 
 export const useQueryParam = (paramName: string) =>
   computed(() => useRoute().query[paramName]);
+
+function isV1Endpoint(endpoint: string) {
+  return endpoint.includes('v1/');
+}

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -6,7 +6,7 @@ export const API_ENDPOINTS = {
   characters: 'v1/characters',
   classes: 'v1/classes',
   conditions: 'v1/conditions',
-  documents: 'v1/documents',
+  documents: 'v2/documents',
   feats: 'v1/feats',
   magicitems: 'v1/magicitems',
   monsters: 'v1/monsters',

--- a/composables/sources.ts
+++ b/composables/sources.ts
@@ -19,8 +19,6 @@ const _sourcesV1 = computed(() => {
   if (!_sources.value || _sources.value.length === 0) return [];
   const sourcemap: { [key: string]: string } = {
     'a5e-ag': 'a5e',
-    'a5e-ddg': 'a5e',
-    'a5e-gpg': 'a5e',
     bfrd: 'blackflag',
     ccdx: 'cc',
     deepm: 'dmag',

--- a/composables/sources.ts
+++ b/composables/sources.ts
@@ -10,6 +10,11 @@ function writeSourcesToLocalStorage(sourcesList: string[]) {
 
 const _sources = ref<string[]>(loadSourcesFromLocalStorage());
 
+/* _sourcesV1 maps Document keys from API V2 onto their V1 equivalents. This
+ * has been added so that we can move the /documents endpoint over to V2 w/o
+ * breaking the seleciton by source functionality for routes pulling from V1.
+ * Keys omitted from the sourcemap will be the same for V1 & V2 endpoints */
+
 const _sourcesV1 = computed(() => {
   if (!_sources.value || _sources.value.length === 0) return [];
   const sourcemap: { [key: string]: string } = {
@@ -19,17 +24,19 @@ const _sourcesV1 = computed(() => {
     bfrd: 'blackflag',
     ccdx: 'cc',
     deepm: 'dmag',
+    deepmx: 'dmag-e',
     mmenag: 'menagerie',
     open5e: 'o5e',
     srd: 'wotc-srd',
     tdcs: 'taldorei',
-    warlock: 'wz',
+    wz: 'warlock',
   };
   return _sources.value.map((source) => {
     if (source in sourcemap) return sourcemap[source];
     return source;
   });
 });
+
 // Overwrite all sources, update local storage
 export const setSources = (sources: string[]) => {
   _sources.value = sources;

--- a/composables/sources.ts
+++ b/composables/sources.ts
@@ -1,5 +1,5 @@
 function loadSourcesFromLocalStorage() {
-  if (!process.client) return []; // skip on server
+  if (!import.meta.client) return []; // skip on server
   const saved_sources = localStorage.getItem('sources');
   return saved_sources ? JSON.parse(saved_sources) : [];
 }
@@ -10,6 +10,27 @@ function writeSourcesToLocalStorage(sourcesList: string[]) {
 
 const _sources = ref<string[]>(loadSourcesFromLocalStorage());
 
+const _sourcesV1 = computed(() => {
+  if (!_sources.value || _sources.value.length === 0) return [];
+  const sourcemap: { [key: string]: string } = {
+    'a5e-ag': 'a5e',
+    'a5e-ddg': 'a5e',
+    'a5e-gpg': 'a5e',
+    bfrd: 'blackflag',
+    ccdx: 'cc',
+    deepm: 'dmag',
+    mmenag: 'menagerie',
+    open5e: 'o5e',
+    srd: 'wotc-srd',
+    tdcs: 'taldorei',
+    warlock: 'wz',
+  };
+  return _sources.value.map((source) => {
+    if (source in sourcemap) return sourcemap[source];
+    return source;
+  });
+});
+// Overwrite all sources, update local storage
 export const setSources = (sources: string[]) => {
   _sources.value = sources;
   writeSourcesToLocalStorage(sources);
@@ -21,6 +42,6 @@ export const read_only_source_list = computed(() => _sources.value);
 export const useSourcesList = () => ({
   /** List of source tags */
   sources: read_only_source_list,
-  /** Overwrite the list of source tags */
   setSources,
+  sourcesAPIVersion1: _sourcesV1,
 });

--- a/composables/spells.ts
+++ b/composables/spells.ts
@@ -36,20 +36,8 @@ export const useSpellsByClass = (
   });
 };
 
-export const useAllSpells = (params: Record<string, any> = {}) => {
-  const { findMany } = useAPI();
-  const { sources } = useSourcesList();
-  return useQuery({
-    queryKey: ['allSpells', API_ENDPOINTS.spells, sources, params],
-    queryFn: async () => {
-      const spells = await findMany(
-        API_ENDPOINTS.spells,
-        sources.value,
-        params
-      );
-      return spells;
-    },
-  });
+export const useAllSpells = async (params: Record<string, any> = {}) => {
+  return await useFindMany(API_ENDPOINTS.spells, params);
 };
 
 const SPELL_LEVELS_NAMES = [

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -56,12 +56,13 @@ import SearchResult from '~/components/SearchResult';
 
 const searchText = useQueryParam('text');
 const { data } = useSearch(searchText);
-const { sources } = useSourcesList();
+const { sourcesAPIVersion1: sources } = useSourcesList();
 
 const results = computed(() => {
   if (!data || !data.value) {
     return;
   }
+
   // split result based on which from currently selected sources
   const [inScope, outScope] = data.value.reduce(
     ([inScope, outScope], item) =>


### PR DESCRIPTION
This PR closes #546 by switching over the frontend site to consume V2 of the Documents endpoint.

Care was taken to ensure that this switch doesn't completely break every other page on the site. It is possible to render the V2 Document `key`s and their equivilent V1 `slug` by using the `sourcesAPIVersion1` method returned by the `useSourcesList()` composable.

A known bug is that this PR breaks source filtering on the spells by class page, but this route is due a rewrite in any case