### PR TITLE
Feature: V2 Monsters

### DIFF
--- a/components/ApiResultRow.vue
+++ b/components/ApiResultRow.vue
@@ -1,11 +1,14 @@
 <template>
   <tr>
     <!-- Render each field defined in columns as a table cell -->
-    <td v-for="col in cols" :key="col.displayName" class="capitalize">
+    <td v-for="col in cols" :key="col.displayName">
       <template v-if="col.link">
-        <nuxt-link :to="col.link(data)">
-          {{ col.value(data) }}
-        </nuxt-link>
+        <span>
+          <nuxt-link :to="col.link(data)">
+            {{ col.value(data) }}
+          </nuxt-link>
+          <source-tag :text="slug" :title="data.document.name" />
+        </span>
       </template>
       <template v-else>
         {{ col.value(data) }}
@@ -15,26 +18,18 @@
 </template>
 
 <script setup>
-import SourceTag from './SourceTag.vue';
-
 const props = defineProps({
-  // API endpoint from which data is sourced. Used to create links
-  endpoint: { type: String, default: '' },
-  // Data for a specific item from the Open5e API
-  data: { type: Object, default: () => {} },
-  // An arr. of which fields in the data prop to render as columns
-  cols: { type: Array, default: () => [] },
+  endpoint: { type: String, default: '' }, // API endpoint source (for links)
+  data: { type: Object, default: () => {} }, // Open5e data to render
+  cols: { type: Array, default: () => [] }, // Arr. of table columns to render
 });
 
-// Result UID has a different btwn API V1 & V2 - handle both 'key' & 'slug'
-const slug = props.data.key ?? props.data.slug;
-
-const format = (input) => {
-  // parse decimals <1 as fractions
-  const asFloat = parseFloat(input);
-  if (asFloat && asFloat < 1 && asFloat > 0) {
-    return `1/${1.0 / asFloat}`;
-  }
-  return input;
-};
+// Workaround for API V2 no returning Document 'key'
+// Extrapolate key from 'url'
+const slug = computed(() =>
+  props.data.document.url
+    .split('/')
+    .filter((exists) => exists)
+    .pop()
+);
 </script>

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -94,7 +94,6 @@ const { data, pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
   });
 
 const results = computed(() => data.value?.results);
-
 const updateSortState = (property) => {
   const column = props.cols.find((col) => col.displayName === property) || {
     sortValue: property,

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -86,7 +86,7 @@ const { data, pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
     isSortDescending: isSortDescending,
     filter: filter,
     params: {
-      fields: ['key', 'slug', 'name'].concat(props.fields).join(),
+      fields: ['key', 'name', 'document'].concat(props.fields).join(),
       depth: 1,
     },
   });

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -65,9 +65,6 @@
 </template>
 
 <script setup>
-import ApiResultRow from './ApiResultRow.vue';
-import SortableTableHeader from './SortableTableHeader.vue';
-
 const sortBy = ref('name');
 const isSortDescending = ref(false);
 
@@ -90,6 +87,7 @@ const { data, pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
     filter: filter,
     params: {
       fields: ['key', 'slug', 'name'].concat(props.fields).join(),
+      depth: 1,
     },
   });
 

--- a/components/FilterInput.vue
+++ b/components/FilterInput.vue
@@ -4,8 +4,9 @@
       :for="id"
       class="floating-label"
       :class="{ 'floating-label--top': isLabelFloating }"
-      >{{ placeholder }}</label
     >
+      {{ placeholder }}
+    </label>
     <input
       :id="id"
       ref="input"

--- a/components/MonsterFilterBox.vue
+++ b/components/MonsterFilterBox.vue
@@ -4,9 +4,11 @@
     class="filter-header-wrapper flex flex-wrap bg-gray-50 px-2 dark:bg-slate-900 dark:text-white"
   >
     <div class="bg-blue flex w-full flex-wrap align-middle">
-      <label for="monsterName" class="pt-1 font-bold md:w-1/6"
-        >MONSTER NAME:</label
-      >
+      <!-- Filter by Monster Name -->
+      <!-- Currently broken, ?name__icontains= not supported by API V2 (yet!) -->
+      <label for="monsterName" class="pt-1 font-bold md:w-1/6">
+        MONSTER NAME:
+      </label>
       <input
         id="monsterName"
         :value="filter.name__icontains"
@@ -15,15 +17,19 @@
         class="mt-2 w-1/2 rounded-md px-2 ring-1 ring-gray-500 focus:ring-2 focus:ring-blood dark:bg-slate-700 dark:text-white md:w-5/6"
         @input="updateFilter('name__icontains', $event.target.value)"
       />
+
+      <!-- Filter by CR (lower bound) -->
       <span class="flex w-full font-bold">CHALLENGE RATING</span>
       <div class="flex w-full px-1 md:w-1/2">
         <label for="challengeRtgLow" class="w-1/2">From:</label>
         <select
           id="challengeRtgLow"
-          :value="filter.cr__gte"
+          :value="filter.challenge_rating_decimal__gte"
           name="challengeRtgLow"
           class="w-1/2 rounded-md ring-1 ring-gray-500 focus:ring-2 focus:ring-blood dark:bg-slate-700 dark:text-white"
-          @input="updateFilter('cr__gte', $event.target.value)"
+          @input="
+            updateFilter('challenge_rating_decimal__gte', $event.target.value)
+          "
         >
           <option :key="''" :value="''" text="Any" />
           <option
@@ -34,14 +40,18 @@
           />
         </select>
       </div>
+
+      <!-- Filter by CR (upper bound) -->
       <div class="flex w-full px-1 md:w-1/2">
         <label for="challengeRtgHigh" class="w-1/2">To:</label>
         <select
           id="challengeRtgHigh"
-          :value="filter.cr__lte"
+          :value="filter.challenge_rating_decimal__lte"
           name="challengeRtgHigh"
           class="w-1/2 rounded-md ring-1 ring-gray-500 focus:ring-2 focus:ring-blood dark:bg-slate-700 dark:text-white"
-          @input="updateFilter('cr__lte', $event.target.value)"
+          @input="
+            updateFilter('challenge_rating_decimal__lte', $event.target.value)
+          "
         >
           <option :key="''" :value="''" text="Any" />
           <option
@@ -53,39 +63,8 @@
         </select>
       </div>
     </div>
-    <div class="flex w-full flex-wrap">
-      <span class="flex w-full font-bold">HIT POINTS</span>
-      <div class="flex w-full px-1 md:w-1/2">
-        <label for="hpLow" class="w-1/2">From (low):</label>
-        <input
-          id="hpLow"
-          :value="filter.hit_points__gte"
-          placeholder="Any"
-          type="number"
-          min="0"
-          max="9999"
-          step="1"
-          name="hpLow"
-          class="w-1/2 rounded-md px-2 ring-1 ring-gray-500 focus:ring-2 focus:ring-blood dark:bg-slate-700 dark:text-white"
-          @input="updateFilter('hit_points__gte', $event.target.value)"
-        />
-      </div>
-      <div class="flex w-full px-1 md:w-1/2">
-        <label for="hpHigh" class="w-1/2">To (high):</label>
-        <input
-          id="hpHigh"
-          :value="filter.hit_points__lte"
-          placeholder="Any"
-          type="number"
-          min="0"
-          max="9999"
-          step="1"
-          name="hpHigh"
-          class="w-1/2 rounded-md px-2 ring-1 ring-gray-500 focus:ring-2 focus:ring-blood dark:bg-slate-700 dark:text-white"
-          @input="updateFilter('hit_points__lte', $event.target.value)"
-        />
-      </div>
-    </div>
+
+    <!-- Filter by Size -->
     <div class="flex w-full flex-wrap pr-1 pt-4 md:w-1/2">
       <label for="size" class="w-1/2 font-bold">SIZE:</label>
       <select
@@ -96,9 +75,17 @@
         @input="updateFilter('size', $event.target.value)"
       >
         <option :key="''" :value="''" text="Any" />
-        <option v-for="size in MONSTER_SIZES_LIST" :key="size" v-text="size" />
+        <option
+          v-for="size in MONSTER_SIZES_LIST"
+          :key="size"
+          :value="size.toLowerCase()"
+          v-text="size"
+        />
       </select>
     </div>
+
+    <!-- Filter by Monster Type -->
+    <!-- Currently broken, ?type= not supported by API V2 (yet!) -->
     <div class="flex w-full flex-wrap pt-4 md:w-1/2">
       <div class="flex w-full px-1">
         <label for="type" class="w-full font-bold">TYPE:</label>

--- a/components/SourceTag.vue
+++ b/components/SourceTag.vue
@@ -16,27 +16,13 @@
 import colors from 'tailwindcss/colors';
 
 const props = defineProps({
-  text: {
-    default: '',
-    type: String,
-  },
-  title: {
-    default: '',
-    type: String,
-  },
-  textColor: {
-    type: String,
-    default: colors.slate[900],
-  },
-  background: {
-    type: String,
-    default: colors.slate[100],
-  },
-  border: {
-    type: String,
-    default: colors.slate[300],
-  },
+  text: { type: String, default: '' },
+  title: { type: String, default: '' },
+  textColor: { type: String, default: colors.slate[900] },
+  background: { type: String, default: colors.slate[100] },
+  border: { type: String, default: colors.slate[300] },
 });
+
 // this creates a quick (but non-cryptographic) numeric hash of the string
 function hashCode(str) {
   let hash = 0;

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -36,7 +36,7 @@ export const useAPI = () => {
       const res = await api.get(endpoint, {
         params: {
           limit: 5000,
-          document__slug__in: formattedSources,
+          document__key__in: formattedSources,
           ...params,
         },
       });
@@ -68,7 +68,7 @@ export const useAPI = () => {
         params: {
           limit: itemsPerPage,
           page: pageNo,
-          document__slug__in: formattedSources,
+          document__key__in: formattedSources,
           ordering: `${isSortDescending ? '-' : ''}${sortByProperty}`,
           ...queryParams,
         },

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -71,7 +71,6 @@ export const useAPI = () => {
           document__slug__in: formattedSources,
           ordering: `${isSortDescending ? '-' : ''}${sortByProperty}`,
           ...queryParams,
-          depth: 1,
         },
       });
 
@@ -86,7 +85,9 @@ export const useAPI = () => {
     },
     get: async (...parts: string[]) => {
       const route = parts.join('');
-      const res = await api.get(route);
+      const res = await api.get(route, {
+        params: { depth: '2' },
+      });
       return res.data as Record<string, any>;
     },
   };

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -9,7 +9,7 @@ export const API_ENDPOINTS = {
   documents: 'v2/documents/',
   feats: 'v1/feats/',
   magicitems: 'v1/magicitems/',
-  monsters: 'v1/monsters/',
+  monsters: 'v2/creatures/',
   races: 'v1/races/',
   search: 'v2/search/',
   sections: 'v1/sections/',
@@ -71,6 +71,7 @@ export const useAPI = () => {
           document__slug__in: formattedSources,
           ordering: `${isSortDescending ? '-' : ''}${sortByProperty}`,
           ...queryParams,
+          depth: 1,
         },
       });
 

--- a/composables/monsters.ts
+++ b/composables/monsters.ts
@@ -27,6 +27,7 @@ export function copyDefaultMonsterFilter(): MonsterFilter {
   return { ...DefaultMonsterFilter };
 }
 
+// Fetch a single monster from Open5e API
 export const useMonster = (slug: string) => {
   const { get } = useAPI();
   return useQuery({

--- a/composables/monsters.ts
+++ b/composables/monsters.ts
@@ -1,24 +1,15 @@
 export type MonsterFilter = {
-  /** Name contains */
-  name__icontains?: string;
-  /** Challenge rating lower bound */
-  cr__gte?: string;
-  /** Challenge rating upper bound */
-  cr__lte?: string;
-  /** HP rating lower bound */
-  hit_points__gte?: string;
-  /** HP rating lower bound */
-  hit_points__lte?: string;
-  size?: string;
-  type?: string;
+  name__icontains?: string; // filter by name (TODO)
+  challenge_rating_decimal_gte?: string; // CR lower bound
+  challenge_rating_decimal__lte?: string; // CR upper bound
+  size?: string; // filter by size
+  type?: string; // filter by monster type (TODO)
 };
 
 export const DefaultMonsterFilter: Readonly<MonsterFilter> = {
   name__icontains: '',
-  cr__gte: '',
-  cr__lte: '',
-  hit_points__gte: '',
-  hit_points__lte: '',
+  challenge_rating_decimal_gte: '',
+  challenge_rating_decimal__lte: '',
   size: '',
   type: '',
 };
@@ -38,21 +29,13 @@ export const useMonster = (slug: string) => {
         name: ability,
         shortName: ability.slice(0, 3),
         score: monster[ability],
-        modifier: formatMod(calcMod(monster[ability])),
+        modifier: useFormatModifier(monster[ability], { inputType: 'score' }),
         save: monster[`${ability}_save`],
       }));
       return monster as Record<string, string>;
     },
   });
 };
-
-function calcMod(score: number) {
-  return Math.floor((score - 10) / 2);
-}
-
-function formatMod(mod: number) {
-  return mod >= 0 ? '+' + mod.toString() : mod.toString();
-}
 
 const ABILITY_SCORE_NAMES = [
   'strength',

--- a/composables/useFormatModifier.ts
+++ b/composables/useFormatModifier.ts
@@ -1,8 +1,11 @@
+/* useFormatModifier generates a formatted modifier from either a numerical
+ * modifier or an ability score. */
+
 export const useFormatModifier = (
   input: string | number,
   options?: {
     inputType?: 'modifier' | 'score';
-    showZero: boolean;
+    showZero?: boolean;
   }
 ) => {
   // set options defaults

--- a/composables/useFormatModifier.ts
+++ b/composables/useFormatModifier.ts
@@ -18,5 +18,6 @@ export const useFormatModifier = (
   // convert score to mod
   const mod = type === 'score' ? Math.floor((inputNum - 10) / 2) : inputNum;
 
-  return (mod < 0 ? '- ' : '+ ') + mod.toString().replace('-', '');
+  // remove '-' from negative numbers, add back a '+' OR '-'
+  return (mod < 0 ? '-' : '+') + mod.toString().replace('-', '');
 };

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -9,7 +9,7 @@
           class="flex items-center gap-1 rounded-md p-1 text-xs text-blood outline outline-1 outline-blood hover:bg-blood hover:text-white"
           @click="toggleMode()"
         >
-          <Icon
+          <icon
             :name="
               mode === 'compact'
                 ? 'heroicons:arrows-pointing-out'
@@ -27,79 +27,217 @@
       class="img-main"
     />
     <p class="italic">
-      <span>
-        {{
-          `${monster.size} ${monster.type}${
-            monster.subtype ? ` (${monster.subtype})` : ''
-          }, ${monster.alignment}`
-        }}
+      <span>{{ `${monster.size.name} ${monster.type.name}` }}</span>
+      <span
+        v-if="monster.subtype"
+        class="before:content-['_('] after:content-[')']"
+      >
+        {{ monster.subtype }}
       </span>
+      <span v-if="monster.alignment" class="before:content-[',_']">
+        {{ monster.alignment }}
+      </span>
+
+      <!-- 
+        Source-tag text param is ugly, but might require work on the API first.
+        Workaround for key not being returned from API. Get it from URL instead
+      -->
       <source-tag
-        v-show="monster.document__slug"
-        :title="monster.document__title"
-        :text="monster.document__slug"
+        :title="monster.document.name"
+        :text="
+          monster.document.url
+            .split('/')
+            .filter((slug) => slug)
+            .slice(-1)[0]
+        "
       />
     </p>
 
-    <section>
-      <ul>
-        <li>
-          <span class="font-bold after:content-['_']">Armor Class</span>
-          {{
-            `${monster.armor_class}${
-              monster.armor_desc ? ` (${monster.armor_desc})` : ''
-            }`
-          }}
-        </li>
-        <li>
-          <span class="font-bold after:content-['_']">Hit Points</span>
-          <span class="after:content-['_']">{{ monster.hit_points }}</span>
-          <span
-            class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-            @click="useDiceRoller(monster.hit_dice)"
-          >
-            {{ `(${monster.hit_dice})` }}
+    <ul>
+      <!-- Size / Type / Alignment / Source Tag -->
+      <li>
+        <span class="font-bold after:content-['_']">Armor Class</span>
+        <span>{{ monster.armor_class }}</span>
+        <span
+          v-if="monster.armor_desc"
+          class="before:content-['_('] after:content-[')']"
+        >
+          {{ monster.armor_desc }}
+        </span>
+      </li>
+      <li>
+        <span class="font-bold after:content-['_']">Hit Points</span>
+        <span class="after:content-['_']">{{ monster.hit_points }}</span>
+        <span
+          v-if="monster.hit_dice"
+          class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
+          @click="useDiceRoller(monster.hit_dice)"
+        >
+          {{ `(${monster.hit_dice})` }}
+        </span>
+      </li>
+
+      <!-- SPEED -->
+      <li>
+        <span class="font-bold after:content-['_']">Speed</span>
+        <span
+          v-for="(speed, key) in speeds"
+          :key="key"
+          class="after:content-[',_'] last:after:content-[]"
+        >
+          <span v-if="key !== 'walk'" class="after:content-['_']">
+            {{ key }}
           </span>
-        </li>
-        <li>
-          <span class="font-bold after:content-['_']">Speed</span>
-          <span
-            v-for="(speed, key) in monster.speed"
-            v-show="key !== 'hover'"
-            :key="key"
-            class="after:content-[',_'] last:after:content-[]"
-          >
-            {{
-              `${key !== 'walk' ? `${key} ` : ''}${speed}ft.${
-                speed.hasOwnProperty('hover') && key === 'fly' ? ' (hover)' : ''
-              }`
-            }}
+          <span class="after:content-['_ft.']">
+            {{ speed }}
           </span>
-        </li>
-      </ul>
-    </section>
+        </span>
+      </li>
+    </ul>
 
     <hr />
 
     <!-- ABILITY SCORES -->
-    <section class="max-w-96">
-      <ul class="flex items-center gap-4 text-center">
-        <li v-for="ability in monster.abilities" :key="ability.name">
-          <span class="block font-bold uppercase">{{ ability.shortName }}</span>
-          <span class="after:content-['_']">{{ ability.score }}</span>
-          <span
-            class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
-            @click="useDiceRoller(ability.modifier)"
-          >
-            {{ `(${ability.modifier})` }}
-          </span>
-        </li>
-      </ul>
-    </section>
+    <ul class="flex max-w-96 items-center gap-4 text-center">
+      <li v-for="(score, ability) in monster.ability_scores" :key="ability">
+        <label class="block font-bold uppercase">
+          {{ ability.substring(0, 3) }}
+        </label>
+        <span class="after:content-['_']">{{ score }}</span>
+        <span
+          class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
+          @click="useDiceRoller(monster.modifiers[ability].toString())"
+        >
+          {{ `(${useFormatModifier(monster.modifiers[ability])})` }}
+        </span>
+      </li>
+    </ul>
 
     <hr />
 
-    <!-- Monster Special Abilities -->
+    <!-- BOX UNDER STATS -->
+    <section>
+      <!-- SAVING THROWS -->
+      <ul v-if="Object.keys(monster.saving_throws).length > 0" id="saves">
+        <label for="saves" class="inline font-bold after:content-['_']">
+          Saving Throws
+        </label>
+        <li
+          v-for="(save, name) in monster.saving_throws"
+          :key="name"
+          class="inline cursor-pointer font-bold text-blood after:content-[',_'] last:after:content-[] hover:text-black dark:hover:text-fog"
+          @click="useDiceRoller(save.toString())"
+        >
+          {{ `${name.toUpperCase().slice(0, 3)} ${useFormatModifier(save)}` }}
+        </li>
+      </ul>
+
+      <!-- SKILLS -->
+      <ul v-if="Object.keys(monster.skill_bonuses).length > 0" id="skills">
+        <label for="skills" class="inline font-bold after:content-['_']">
+          Skills
+        </label>
+        <li
+          v-for="(modifier, skill) in monster.skill_bonuses"
+          :key="skill"
+          class="inline cursor-pointer font-bold capitalize text-blood after:content-[',_'] last:after:content-[] hover:text-black dark:hover:text-fog"
+          @click="useDiceRoller(modifier.toString())"
+        >
+          {{ `${skill} ${useFormatModifier(modifier)}` }}
+        </li>
+      </ul>
+
+      <!-- DAMAGE IMMUNITIES -->
+      <ul v-if="damageImmunities.length > 0" id="dmg-immunities">
+        <label
+          for="dmg-immunities"
+          class="inline font-bold after:content-['_']"
+        >
+          Damage Immunities
+        </label>
+        <li
+          v-for="immunity in damageImmunities"
+          :key="immunity.name"
+          class="inline capitalize after:content-[',_'] last:after:content-[]"
+        >
+          {{ immunity.name }}
+        </li>
+      </ul>
+
+      <!-- DAMAGE RESISTANCES -->
+      <ul v-if="damageResistances.length > 0" id="dmg-resistances">
+        <label
+          for="dmg-resistances"
+          class="inline font-bold after:content-['_']"
+        >
+          Damage Resistances
+        </label>
+        <li
+          v-for="resistance in damageResistances"
+          :key="resistance.name"
+          class="inline after:content-[',_'] last:after:content-['']"
+        >
+          {{ resistance.name }}
+        </li>
+      </ul>
+
+      <!-- CONDITION IMMUNITIES -->
+      <ul v-if="monster.condition_immunities.length > 0" id="conditions">
+        <label for="conditions" class="inline font-bold after:content-['_']">
+          Condition Immunities
+        </label>
+        <li
+          v-for="immunity in monster.condition_immunities"
+          :key="immunity.name"
+          class="inline capitalize after:content-[',_'] last:after:content-[]"
+        >
+          {{ immunity.name }}
+        </li>
+      </ul>
+
+      <!-- SENSES -->
+      <ul id="senses">
+        <span for="senses" class="inline font-bold after:content-['_']">
+          Senses
+        </span>
+        <li
+          v-for="(value, sense) in senses"
+          :key="sense"
+          class="inline after:content-[',_'] last:after:content-[]"
+        >
+          {{ `${sense} ${value}` }}
+        </li>
+      </ul>
+
+      <!-- LANGUAGES -->
+      <ul id="languages">
+        <span for="languages" class="inline font-bold after:content-['_']">
+          Languages
+        </span>
+        <li
+          v-for="language in monster.languages"
+          :key="language.name"
+          class="inline after:content-[',_'] last:after:content-[]"
+        >
+          {{ language.name }}
+        </li>
+        <li v-if="monster.languages.length === 0" class="inline">-</li>
+      </ul>
+
+      <!-- CHALLENGE -->
+      <ul id="challenge">
+        <span for="challenge" class="inline font-bold after:content-['_']">
+          Challenge
+        </span>
+        <span>
+          {{
+            `${monster.challenge_rating_text} (${monster.experience_points} XP)`
+          }}
+        </span>
+      </ul>
+    </section>
+
+    <!-- SPECIAL ABILITIES -->
     <section v-if="monster.special_abilities">
       <p
         v-for="ability in monster.special_abilities"
@@ -111,18 +249,23 @@
       </p>
     </section>
 
-    <!-- Monster Actions -->
-    <section v-if="monster.actions">
+    <!-- ACTIONS -->
+    <section v-if="monster.actions.length !== 0">
       <h2>Actions</h2>
       <ul id="actions-list">
         <li v-for="action in monster.actions" :key="action.name" class="my-1">
-          <span class="font-bold after:content-['_']">{{ action.name }}. </span>
+          <span class="font-bold after:content-['._']">
+            <span>{{ action.name }}</span>
+            <span v-if="action.recharge_on_roll" class="before:content-['_']">
+              {{ `(Recharge ${action.recharge_on_roll}-6)` }}
+            </span>
+          </span>
           <md-viewer :inline="true" :text="action.desc" :use-roller="true" />
         </li>
       </ul>
     </section>
 
-    <!-- Monster Bonus Actions -->
+    <!-- BONUS ACTIONS -->
     <section v-if="monster.bonus_actions">
       <h2>Bonus Actions</h2>
       <ul>
@@ -137,7 +280,7 @@
       </ul>
     </section>
 
-    <!-- Monster Reactions -->
+    <!-- REACTIONS -->
     <section v-if="monster.reactions">
       <h2>Reactions</h2>
       <ul>
@@ -148,7 +291,7 @@
       </ul>
     </section>
 
-    <!-- Monster Legendary Actions -->
+    <!-- LEGENDARY ACTIONS -->
     <section v-if="monster.legendary_actions">
       <h2>Legendary Actions</h2>
       <p v-if="monster.legendary_desc" class="text">
@@ -166,7 +309,8 @@
         </li>
       </ul>
     </section>
-    <!-- Monster Mythic Actions -->
+
+    <!-- MYTHIC ACTIONS -->
     <section v-if="monster.mythic_actions">
       <h2>Mythic Actions</h2>
       <ul>
@@ -181,7 +325,7 @@
       </ul>
     </section>
 
-    <!-- Monster Lair and Lair Actions -->
+    <!-- LAIR ACTIONS -->
     <section v-if="monster.lair_actions">
       <h2>Lair Actions</h2>
       <p v-if="monster.lair_desc" class="text">
@@ -199,7 +343,7 @@
       </ul>
     </section>
 
-    <!-- Monster Description -->
+    <!-- DESCRIPTION -->
     <section v-if="monster.desc">
       <h2>Description</h2>
       <md-viewer :text="monster.desc" />
@@ -221,8 +365,8 @@
 
     <p class="mb-4 text-sm italic">
       Source:
-      <a target="NONE" :href="monster.document__url">
-        {{ monster.document__title }}
+      <a target="NONE" :href="monster.document.permalink">
+        {{ monster.document.name }}
         <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
       </a>
     </p>
@@ -231,7 +375,60 @@
 
 <script setup>
 const route = useRoute();
-const { data: monster } = useMonster(route.params.id);
+const { data: monster } = useFindOne(
+  API_ENDPOINTS.monsters,
+  useRoute().params.id,
+  ['document']
+);
+
+// filter "unit" prop from "speeds"
+const speeds = computed(() => {
+  const { unit, ...rest } = monster.value.speed;
+  return rest;
+});
+
+// assemble senses from multiple fields
+const senses = computed(() => {
+  const senses = {};
+  if (monster.value.darkvision_range)
+    senses['Darkvision'] = monster.value.darkvision_range + ' ft.';
+  if (monster.value.blindsight_range)
+    senses['Blindsight'] = monster.value.blindsight_range + ' ft.';
+  if (monster.value.tremorsense_range)
+    senses['Tremorsense'] = monster.value.tremorsense_range + ' ft.';
+  if (monster.value.truesight_range)
+    senses['Truesight'] = monster.value.truesight_range + ' ft.';
+  senses['Passive Perception'] = monster.value.passive_perception;
+  return senses;
+});
+
+// format damage resistances correctly (damage from non-magic weapons)
+const damageResistances = computed(() => {
+  if (!monster.value.nonmagical_attack_resistance)
+    return monster.value.damage_resistances;
+  return [
+    ...monster.value.damage_resistances.filter(
+      (res) => !['Bludgeoning', 'Slashing', 'Piercing'].includes(res.name)
+    ),
+    {
+      name: 'Bludgeoning, Piercing and Slashing from Nonmagical Attacks',
+    },
+  ];
+});
+
+// format damage resistances correctly (damage from non-magic weapons)
+const damageImmunities = computed(() => {
+  if (!monster.value.nonmagical_attack_immunity)
+    return monster.value.damage_immunities;
+  return [
+    ...monster.value.damage_immunities.filter(
+      (res) => !['Bludgeoning', 'Slashing', 'Piercing'].includes(res.name)
+    ),
+    {
+      name: 'Bludgeoning, Piercing and Slashing from Nonmagical Attacks',
+    },
+  ];
+});
 
 const mode = ref(route.query.mode || 'normal');
 function toggleMode() {

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -34,6 +34,7 @@
           'challenge_rating_decimal',
           'document',
           'type',
+          'size',
         ]"
         :cols="[
           {
@@ -50,6 +51,10 @@
           {
             displayName: 'Type',
             value: (data) => data.type.name,
+          },
+          {
+            displayName: 'Size',
+            value: (data) => data.size.name,
           },
         ]"
       />

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -2,7 +2,7 @@
   <section class="docs-container container">
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Monster List</h1>
-      <FilterButton
+      <filter-button
         :show-clear-button="canClearFilter"
         :filter-count="enabeledFiltersCount"
         :filter-shown="displayFilter"
@@ -10,7 +10,7 @@
         @clear-filter="clear"
       />
     </div>
-    <MonsterFilterBox
+    <monster-filter-box
       v-if="displayFilter"
       ref="monsterFilterBox"
       :filter="filter"
@@ -29,7 +29,20 @@
         v-model="debouncedFilter"
         endpoint="monsters"
         :api-endpoint="API_ENDPOINTS.monsters"
-        :cols="['type', 'cr', 'size', 'hit_points']"
+        :fields="['challenge_rating_decimal']"
+        :cols="[
+          {
+            displayName: 'Name',
+            value: (data) => data.name,
+            sortValue: 'name',
+            link: (data) => `/monsters/${data.key}`,
+          },
+          {
+            displayName: 'CR',
+            value: (data) => data.challenge_rating_decimal,
+            sortValue: 'challenge_rating_decimal',
+          },
+        ]"
       />
     </div>
   </section>

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -29,7 +29,12 @@
         v-model="debouncedFilter"
         endpoint="monsters"
         :api-endpoint="API_ENDPOINTS.monsters"
-        :fields="['challenge_rating_decimal']"
+        :fields="[
+          'challenge_rating_text',
+          'challenge_rating_decimal',
+          'document',
+          'type',
+        ]"
         :cols="[
           {
             displayName: 'Name',
@@ -39,8 +44,12 @@
           },
           {
             displayName: 'CR',
-            value: (data) => data.challenge_rating_decimal,
+            value: (data) => data.challenge_rating_text,
             sortValue: 'challenge_rating_decimal',
+          },
+          {
+            displayName: 'Type',
+            value: (data) => data.type.name,
           },
         ]"
       />
@@ -49,10 +58,6 @@
 </template>
 
 <script setup>
-import ApiResultsTable from '~/components/ApiResultsTable.vue';
-import FilterButton from '~/components/FilterButton.vue';
-import MonsterFilterBox from '~/components/MonsterFilterBox.vue';
-
 const displayFilter = ref(false);
 
 const {


### PR DESCRIPTION
Closes #547 by refactoring the `/monsters` and `/monsters/[id]` routes to pull data from Open5e API V2.

Care was taken to preserve as much functionality as possible from V1, but some features no longer worker. I did not fix these because, as far as I can tell, each issue would either require either 1) work on the API, or 2) a great deal of additional refactoring that would be better handled in its own PR.

Here are the things I have observed which could use further work.

- **Filtering monster table by `name` or `type`**. Filtering by these fields doesn't appear to be supported by V2 of the API just yet.
- **Sorting monster table by `size` or `type`**. This will require a more thorough refactor of the results table, as these fields now return objects instead of the size/type in plain-text
- **Monster abilities missing**. These don't appear to be returned by the API just yet, perhaps a work-in-progress?
- **Ugly Breadcrumbs**. With many monster primary-keys changing to be prefixed by the key of the source they were pulled from, navigation breadcrumbs are looking a little ratty. This should be fairly straightforward, but is outside the scope of this PR