### PR TITLE
Feature: V2 Magic Items

### DIFF
--- a/components/ApiResultRow.vue
+++ b/components/ApiResultRow.vue
@@ -10,6 +10,10 @@
           <source-tag :text="slug" :title="data.document.name" />
         </span>
       </template>
+      <!-- If data is boolean, display as √ or -, not true or false  -->
+      <template v-else-if="typeof col.value(data) === 'boolean'">
+        <span>{{ col.value(data) ? '√' : '-' }}</span>
+      </template>
       <template v-else>
         {{ col.value(data) }}
       </template>

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -74,6 +74,7 @@ const props = defineProps({
   itemsPerPage: { type: Number, default: 50 },
   fields: { type: Array, default: () => [] },
   cols: { type: Array, default: () => [] },
+  params: { type: Object, default: () => {} },
 });
 
 const filter = defineModel({ default: () => ({}), type: Object });
@@ -86,6 +87,7 @@ const { data, pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
     isSortDescending: isSortDescending,
     filter: filter,
     params: {
+      ...props.params,
       fields: ['key', 'name', 'document'].concat(props.fields).join(),
       depth: 1,
     },

--- a/components/MagicItemFilterBox.vue
+++ b/components/MagicItemFilterBox.vue
@@ -4,6 +4,8 @@
     class="filter-header-wrapper flex flex-wrap bg-gray-50 px-2 dark:bg-slate-900 dark:text-white"
   >
     <div class="bg-blue flex w-full flex-wrap align-middle">
+      <!-- FILTER BY ITEM NAME -->
+      <!-- TODO: filtering by name unsupported by API (2 Sep. 24) -->
       <label for="itemName" class="pt-1 font-bold md:w-1/6">ITEM NAME:</label>
       <input
         id="itemName"
@@ -13,6 +15,9 @@
         class="mt-2 w-1/2 rounded-md px-2 ring-1 ring-gray-500 focus:ring-2 focus:ring-blood dark:bg-slate-700 dark:text-white md:w-5/6"
         @input="updateFilter('name__icontains', $event.target.value)"
       />
+
+      <!-- FILTER BY MAGIC ITEM RARITY -->
+      <!-- TODO: filtering by rarity unsupported by API (2 Sep. 24) -->
       <div class="flex w-full flex-wrap">
         <div class="mt-2 flex w-full flex-wrap md:w-1/2">
           <span class="mr-2 w-full font-bold">RARITY:</span>
@@ -27,11 +32,14 @@
             <option
               v-for="rtg in MAGIC_ITEMS_RARITES"
               :key="rtg"
-              class=""
+              :value="rtg"
               v-text="rtg"
             />
           </select>
         </div>
+
+        <!-- FILTER BY MAGIC ITEM TYPE -->
+        <!-- TODO: filtering by type unsupported by API (2 Sep. 24) -->
         <div class="mt-2 flex w-full flex-wrap md:w-1/2">
           <span class="mr-2 w-full font-bold md:ml-2">TYPE:</span>
           <select
@@ -50,6 +58,8 @@
             />
           </select>
         </div>
+
+        <!-- FILTER BY ATTUNEMENT REQUIREMENT -->
         <div class="mt-4 flex w-full md:w-1/2">
           <span class="mr-2 font-bold">REQUIRES ATTUNEMENT:</span>
           <input

--- a/components/MagicItemFilterBox.vue
+++ b/components/MagicItemFilterBox.vue
@@ -56,12 +56,12 @@
             id="attunement"
             :value="filter.requires_attunement"
             type="checkbox"
-            name="attunement"
+            name="requires_attunement"
             class="mb-1 accent-blood"
             @input="
               updateFilter(
                 'requires_attunement',
-                $event.target.value ? '' : 'requires attunement'
+                $event.target.value === 'on' ? true : undefined
               )
             "
           />

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -8,7 +8,7 @@ export const API_ENDPOINTS = {
   conditions: 'v1/conditions/',
   documents: 'v2/documents/',
   feats: 'v1/feats/',
-  magicitems: 'v1/magicitems/',
+  magicitems: 'v2/items/',
   monsters: 'v2/creatures/',
   races: 'v1/races/',
   search: 'v2/search/',

--- a/composables/magic-items.ts
+++ b/composables/magic-items.ts
@@ -1,15 +1,15 @@
 export type MagicItemFilter = {
   /** Name contains*/
   name__icontains?: string;
-  rarity?: string;
-  type?: typeof MAGIC_ITEMS_TYPES | '';
+  rarity?: Object;
+  category?: Object;
   requires_attunement?: 'requires attunement' | '';
 };
 
 export const DefaultMagicItemFilter: Readonly<MagicItemFilter> = {
   name__icontains: '',
-  rarity: '',
-  type: '',
+  rarity: {},
+  category: {},
   requires_attunement: '',
 };
 

--- a/composables/magic-items.ts
+++ b/composables/magic-items.ts
@@ -10,7 +10,7 @@ export const DefaultMagicItemFilter: Readonly<MagicItemFilter> = {
   name__icontains: '',
   rarity: {},
   category: {},
-  requires_attunement: false,
+  requires_attunement: undefined,
 };
 
 export const copyMagicItemFilter = (): MagicItemFilter => {

--- a/composables/magic-items.ts
+++ b/composables/magic-items.ts
@@ -1,15 +1,15 @@
 export type MagicItemFilter = {
   /** Name contains*/
   name__icontains?: string;
-  rarity?: Object;
-  category?: Object;
+  rarity?: string;
+  category?: string;
   requires_attunement?: boolean;
 };
 
 export const DefaultMagicItemFilter: Readonly<MagicItemFilter> = {
   name__icontains: '',
-  rarity: {},
-  category: {},
+  rarity: '',
+  category: '',
   requires_attunement: undefined,
 };
 

--- a/composables/magic-items.ts
+++ b/composables/magic-items.ts
@@ -3,14 +3,14 @@ export type MagicItemFilter = {
   name__icontains?: string;
   rarity?: Object;
   category?: Object;
-  requires_attunement?: 'requires attunement' | '';
+  requires_attunement?: boolean;
 };
 
 export const DefaultMagicItemFilter: Readonly<MagicItemFilter> = {
   name__icontains: '',
   rarity: {},
   category: {},
-  requires_attunement: '',
+  requires_attunement: false,
 };
 
 export const copyMagicItemFilter = (): MagicItemFilter => {

--- a/pages/magic-items/[id].vue
+++ b/pages/magic-items/[id].vue
@@ -1,14 +1,12 @@
 <template>
   <section class="docs-container container">
     <div v-if="item">
-      <h1 class="inline">
-        {{ item.name }}
-      </h1>
+      <h1 class="inline">{{ item.name }}</h1>
       <p>
         <em>
-          {{ item.type }}, {{ item.rarity }}
+          {{ item.category.name }}, {{ item.rarity.name }}
           <span v-show="item.requires_attunement">
-            ({{ item.requires_attunement }})
+            ({{ 'requires attunement' }})
           </span>
         </em>
         <source-tag
@@ -20,8 +18,8 @@
       <md-viewer :text="item.desc" />
       <p class="text-sm italic">
         Source:
-        <a target="NONE" :href="item.document__url">
-          {{ item.document__title }}
+        <a target="NONE" :href="item.document.permalink">
+          {{ item.document.name }}
           <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
         </a>
       </p>

--- a/pages/magic-items/index.vue
+++ b/pages/magic-items/index.vue
@@ -2,7 +2,7 @@
   <section class="docs-container container">
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Magic Item List</h1>
-      <FilterButton
+      <filter-button
         :show-clear-button="canClearFilter"
         :filter-count="enabeledFiltersCount"
         :filter-shown="displayFilter"
@@ -10,7 +10,7 @@
         @clear-filter="clear"
       />
     </div>
-    <MagicItemFilterBox
+    <magic-item-filter-box
       v-if="displayFilter"
       :filter="filter"
       :update-filter="update"
@@ -28,15 +28,32 @@
         v-model="debouncedFilter"
         endpoint="magic-items"
         :api-endpoint="API_ENDPOINTS.magicitems"
-        :cols="['type', 'rarity', 'requires_attunement']"
+        :fields="['category', 'rarity']"
+        :params="{ is_magic_item: true }"
+        :cols="[
+          {
+            displayName: 'Name',
+            value: (data) => data.name,
+            sortValue: 'name',
+            link: (data) => `/magic-items/${data.key}`,
+          },
+          {
+            displayName: 'Category',
+            value: (data) => data.category.name,
+            sortValue: 'category.name',
+          },
+          {
+            displayName: 'Rarity',
+            value: (data) => data.rarity.name,
+            sortValue: 'rarity.name',
+          },
+        ]"
       />
     </div>
   </section>
 </template>
 
 <script setup>
-import FilterButton from '~/components/FilterButton.vue';
-
 const displayFilter = ref(false);
 
 const {

--- a/pages/magic-items/index.vue
+++ b/pages/magic-items/index.vue
@@ -28,7 +28,7 @@
         v-model="debouncedFilter"
         endpoint="magic-items"
         :api-endpoint="API_ENDPOINTS.magicitems"
-        :fields="['category', 'rarity']"
+        :fields="['category', 'rarity', 'requires_attunement']"
         :params="{ is_magic_item: true }"
         :cols="[
           {
@@ -40,12 +40,14 @@
           {
             displayName: 'Category',
             value: (data) => data.category.name,
-            sortValue: 'category.name',
           },
           {
             displayName: 'Rarity',
             value: (data) => data.rarity.name,
-            sortValue: 'rarity.name',
+          },
+          {
+            displayName: 'Requires Attunement',
+            value: (data) => data.requires_attunement,
           },
         ]"
       />


### PR DESCRIPTION
Closes #548 by updating the `/magic-items` and `/magic-items/[id]` pages to pull their data from V2 of the Open5e API.

A few things worth documenting for posterity:

- **Filtering by `Category` and `Rarity`**. Filtering by these fields isn't currently possible as it doesn't yet appear to be supported by the API
- **Sorting by `Category` and `Rarity`**. This will require a more thorough refactor of the results table, as these fields now return objects instead of the size/type in plain-text. The same issue was encountered when updating the Monsters page to V2 (#562)