### PR TITLE
Feature: V2 Breadcrumb

### DIFF
--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -40,5 +40,5 @@
 </template>
 
 <script setup>
-const crumbs = inject('crumbs');
+const crumbs = useBreadcrumbs();
 </script>

--- a/composables/useBreadcrumbs.ts
+++ b/composables/useBreadcrumbs.ts
@@ -14,17 +14,17 @@ export const useBreadcrumbs = () => {
     return (
       route.fullPath
         .split('/')
-        .map((segment) => {
+        .map((pathSegment) => {
           // ignore initial & trailing slashes
-          if (segment === '' || segment === '/') {
+          if (pathSegment === '' || pathSegment === '/') {
             return;
           }
           // rebuild link urls segment by segment
-          url += `/${segment}`;
+          url += `/${pathSegment}`;
 
           // return a breadcrumb object
           return {
-            ...generateTitle(segment),
+            ...generateTitles(pathSegment),
             url,
           } as Breadcrumb;
         })
@@ -35,22 +35,28 @@ export const useBreadcrumbs = () => {
   });
 };
 
-const generateTitle = (crumb: string) => {
+const generateTitles = (crumb: string) => {
   // if on the search route, make 'text' query param subtitle
   if (crumb.indexOf('?') > 0) {
     const [route, queryParams] = crumb.split('?');
-    const title = route.split('-').join(' ');
-    const subtitle = queryParams.split('text=')[1].split('+').join(' ');
-    return { title, subtitle };
+    return {
+      title: formatTitle(route),
+      subtitle: queryParams.split('text=')[1].split('+').join(' '),
+    };
   }
   // if viewing an API item, move source UID in URL to subtitle
   if (crumb.indexOf('_') > 0) {
     const [sourceKey, url] = crumb.split('_');
-    const title = url.split('-').join(' ');
-    const subtitle = sourceKey.toUpperCase();
-    return { title, subtitle };
+    return { title: formatTitle(url), subtitle: sourceKey.toUpperCase() };
   }
 
   // base-case: return crumb as title without subtitle
-  return { title: crumb.split('-').join(' '), subtitle: '' };
+  return { title: formatTitle(crumb), subtitle: '' };
+};
+
+const formatTitle = (title: string) => {
+  return title
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
 };

--- a/composables/useBreadcrumbs.ts
+++ b/composables/useBreadcrumbs.ts
@@ -22,23 +22,10 @@ export const useBreadcrumbs = () => {
           // rebuild link urls segment by segment
           url += `/${segment}`;
 
-          // seperate segment title & query params
-          const [title, queryParams] = segment.split('?');
-
-          // extract & format the search params if on the /search route
-          let searchParam = '';
-          if (title === 'search' && queryParams) {
-            searchParam = queryParams.split('text=')[1].split('+').join(' ');
-          }
-
           // return a breadcrumb object
           return {
+            ...generateTitle(segment),
             url,
-            title: title
-              .split(/[-_]/)
-              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-              .join(' '),
-            subtitle: searchParam,
           } as Breadcrumb;
         })
 
@@ -46,4 +33,24 @@ export const useBreadcrumbs = () => {
         .filter((breadcrumb) => breadcrumb)
     );
   });
+};
+
+const generateTitle = (crumb: string) => {
+  // if on the search route, make 'text' query param subtitle
+  if (crumb.indexOf('?') > 0) {
+    const [route, queryParams] = crumb.split('?');
+    const title = route.split('-').join(' ');
+    const subtitle = queryParams.split('text=')[1].split('+').join(' ');
+    return { title, subtitle };
+  }
+  // if viewing an API item, move source UID in URL to subtitle
+  if (crumb.indexOf('_') > 0) {
+    const [sourceKey, url] = crumb.split('_');
+    const title = url.split('-').join(' ');
+    const subtitle = sourceKey.toUpperCase();
+    return { title, subtitle };
+  }
+
+  // base-case: return crumb as title without subtitle
+  return { title: crumb.split('-').join(' '), subtitle: '' };
 };

--- a/composables/useBreadcrumbs.ts
+++ b/composables/useBreadcrumbs.ts
@@ -1,0 +1,49 @@
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+
+type Breadcrumb = {
+  url: string;
+  title: string;
+  subtitle: string;
+};
+
+export const useBreadcrumbs = () => {
+  const route = useRoute();
+  return computed(() => {
+    let url = '';
+    return (
+      route.fullPath
+        .split('/')
+        .map((segment) => {
+          // ignore initial & trailing slashes
+          if (segment === '' || segment === '/') {
+            return;
+          }
+          // rebuild link urls segment by segment
+          url += `/${segment}`;
+
+          // seperate segment title & query params
+          const [title, queryParams] = segment.split('?');
+
+          // extract & format the search params if on the /search route
+          let searchParam = '';
+          if (title === 'search' && queryParams) {
+            searchParam = queryParams.split('text=')[1].split('+').join(' ');
+          }
+
+          // return a breadcrumb object
+          return {
+            url,
+            title: title
+              .split(/[-_]/)
+              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+              .join(' '),
+            subtitle: searchParam,
+          } as Breadcrumb;
+        })
+
+        // remove null-ish crumbs
+        .filter((breadcrumb) => breadcrumb)
+    );
+  });
+};

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -123,15 +123,11 @@ import { computed } from 'vue';
 // Generate page title from Breadcrumbs
 const BASE_TITLE = 'Open5e';
 const crumbs = useBreadcrumbs();
-
 const title = computed(() => {
   if (crumbs.value.length === 0) {
     return BASE_TITLE;
   }
-  const crumb_titles = crumbs.value.map((crumb) => crumb.title);
-  const reversed_titles = [...crumb_titles].reverse();
-
-  return reversed_titles.join(' - ') + ` - ${BASE_TITLE}`;
+  return `${crumbs.value.at(-1).title} – ${BASE_TITLE}`;
 });
 useHead({ title: title });
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -120,6 +120,21 @@
 import { useRoute } from 'nuxt/app';
 import { computed } from 'vue';
 
+// Generate page title from Breadcrumbs
+const BASE_TITLE = 'Open5e';
+const crumbs = useBreadcrumbs();
+
+const title = computed(() => {
+  if (crumbs.value.length === 0) {
+    return BASE_TITLE;
+  }
+  const crumb_titles = crumbs.value.map((crumb) => crumb.title);
+  const reversed_titles = [...crumb_titles].reverse();
+
+  return reversed_titles.join(' - ') + ` - ${BASE_TITLE}`;
+});
+useHead({ title: title });
+
 const spellcastingClasses = [
   { name: 'Spells by Class', slug: 'by-class' },
   { name: 'Bard Spells', slug: 'by-class/bard' },
@@ -134,55 +149,6 @@ const showSidebar = ref(false);
 
 const $route = useRoute();
 
-const crumbs = computed(() => {
-  let url = '';
-
-  return useRoute()
-    .fullPath.split('/')
-    .map((segment) => {
-      // ignore initial & trailing slashes
-      if (segment === '' || segment === '/') {
-        return;
-      }
-
-      // rebuild link urls segment by segment
-      url += `/${segment}`;
-
-      // seperate segment title & query params
-      const [title, queryParams] = segment.split('?');
-
-      // extract & format the search params if on the /search route
-      let searchParam = '';
-      if (title === 'search' && queryParams) {
-        searchParam = queryParams.split('text=')[1].split('+').join(' ');
-      }
-
-      // return a
-      return {
-        url,
-        title: title // format crumb title
-          .split(/[-_]/)
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(' '),
-        subtitle: searchParam,
-      };
-    })
-    .filter((breadcrumb) => breadcrumb);
-});
-provide('crumbs', crumbs);
-
-const BASE_TITLE = 'Open5e';
-
-const title = computed(() => {
-  if (crumbs.value.length === 0) {
-    return BASE_TITLE;
-  }
-  const crumb_titles = crumbs.value.map((crumb) => crumb.title);
-  const reversed_titles = [...crumb_titles].reverse();
-
-  return reversed_titles.join(' - ') + ` - ${BASE_TITLE}`;
-});
-useHead({ title: title });
 const searchText = ref($route.query.text);
 
 watch(


### PR DESCRIPTION
With the changes to primary key conventions in Open5e API V2, the way we generated our breadcrumb links needed to be updated to ensure they still still looked good.

1) Primary keys for items now contain the key/UID of the source they were pulled from as a prefix to the item title. These have been moved to the end of the crumb, styled differently, and wrapped in parantheses to move it clear they are not part of the API entries name: ie. **SRD GOBLIN**  -> **GOBLIN** (SRD)

2) A more root and branch refactor of the breadcrumbing code, which has been moved from the script tag of the layout component into the `useBreadcrumbs()` composable. This ensures the modularity of the`<BreadcrumbLinks>` component, and another other future component which will require breadcrumbing of the path. 