### PR TITLE
Bugfix: updated filtering and sorting on `/monsters`

### DIFF
--- a/components/MonsterFilterBox.vue
+++ b/components/MonsterFilterBox.vue
@@ -5,7 +5,6 @@
   >
     <div class="bg-blue flex w-full flex-wrap align-middle">
       <!-- Filter by Monster Name -->
-      <!-- Currently broken, ?name__icontains= not supported by API V2 (yet!) -->
       <label for="monsterName" class="pt-1 font-bold md:w-1/6">
         MONSTER NAME:
       </label>
@@ -85,7 +84,6 @@
     </div>
 
     <!-- Filter by Monster Type -->
-    <!-- Currently broken, ?type= not supported by API V2 (yet!) -->
     <div class="flex w-full flex-wrap pt-4 md:w-1/2">
       <div class="flex w-full px-1">
         <label for="type" class="w-full font-bold">TYPE:</label>
@@ -100,7 +98,8 @@
           <option
             v-for="monsterType in MONSTER_TYPES_LIST"
             :key="monsterType"
-            v-text="monsterType"
+            :value="monsterType.toLowerCase()"
+            :text="monsterType"
           />
         </select>
       </div>

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -51,10 +51,12 @@
           {
             displayName: 'Type',
             value: (data) => data.type.name,
+            sortValue: 'type',
           },
           {
             displayName: 'Size',
             value: (data) => data.size.name,
+            sortValue: 'size',
           },
         ]"
       />


### PR DESCRIPTION
This PR fixes a few problems outlined in PR #562 with filtering and sorting on the `/monsters` top-level page:
- Monster table now sortable by `size` and `type`
- Monster table now filterable by partial match on `name` field
- Monster table now filterable by exact match on `type` field

Some of these changes depend on https://github.com/open5e/open5e-api/pull/530 which enables filtering by a partial matches on the `'name'` field and exact match on `'type'` field on the API. Nothing breaks run against the current commit on the staging branch of open5e-api