### PR TITLE
API V2 - Backgrounds

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -44,9 +44,6 @@ table {
   h3,
   h5,
   h6 {
-    display: flex;
-    align-content: flex-start;
-
     .toc-anchor {
       order: 2;
       display: none;

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -2,7 +2,7 @@ import { keepPreviousData, useQuery } from '@tanstack/vue-query';
 import axios from 'axios';
 
 export const API_ENDPOINTS = {
-  backgrounds: 'v1/backgrounds/',
+  backgrounds: 'v2/backgrounds/',
   characters: 'v1/characters/',
   classes: 'v1/classes/',
   conditions: 'v1/conditions/',

--- a/pages/backgrounds/[id].vue
+++ b/pages/backgrounds/[id].vue
@@ -4,15 +4,48 @@
       <div>
         <h1 class="inline">{{ background.name }}</h1>
         <source-tag
+          class="inline"
           :title="background.document.name"
-          :text="background.document.name"
+          :text="
+            background.document.url
+              .split('/')
+              .filter((exists) => exists)
+              .pop()
+          "
         />
       </div>
       <md-viewer :text="background.desc" />
     </section>
+
+    <!-- List of proficiencies & other short, mechanical benefits -->
+    <dl class="mt-2">
+      <div v-for="benefit in benefits.proficiencies" :key="benefit.name">
+        <dt class="inline font-bold">{{ benefit.name }}</dt>
+        <dd class="inline before:content-['._']">{{ benefit.desc }}</dd>
+      </div>
+    </dl>
+
+    <!-- List of background features -->
     <ul>
-      <li v-for="benefit in background.benefits" :key="benefit.name">
-        <h2>{{ benefit.name }}</h2>
+      <li v-for="benefit in benefits.features" :key="benefit.name">
+        <h2>{{ `Feature: ${benefit.name}` }}</h2>
+        <md-viewer :text="benefit.desc" />
+      </li>
+    </ul>
+    <hr />
+
+    <!-- List of background flavour, rollable tables, etc. -->
+    <ul>
+      <li v-for="benefit in benefits.flavour" :key="benefit.name">
+        <h3>
+          <span
+            v-if="benefit.type === 'feature'"
+            class="mr-2 capitalize after:content-[':_']"
+          >
+            {{ benefit.type }}
+          </span>
+          <span>{{ benefit.name }}</span>
+        </h3>
         <md-viewer :text="benefit.desc" />
       </li>
     </ul>
@@ -25,4 +58,35 @@ const { data: background } = useFindOne(
   API_ENDPOINTS.backgrounds,
   useRoute().params.id
 );
+
+// sort benefits into different sections
+// different sections will be rendered to different parts of the page
+const benefits = computed(() => {
+  const [proficiencies, features, flavour] = background.value.benefits.reduce(
+    (acc, benefit) => {
+      // sort profs, langs, equipment, &c into 'proficiencies'
+      if (
+        [
+          'equipment',
+          'language',
+          'skill_proficiency',
+          'tool_proficiency',
+          'ability_score',
+        ].includes(benefit.type)
+      ) {
+        return [[...acc[0], benefit], acc[1], acc[2]];
+      }
+
+      // sort features into 'features'
+      if (benefit.type === 'feature') {
+        return [acc[0], [...acc[1], benefit], acc[2]];
+      }
+
+      // base-case: sort remaining benefits into 'flavour'
+      return [acc[0], acc[1], [...acc[2], benefit]];
+    },
+    [[], [], []]
+  );
+  return { proficiencies, features, flavour };
+});
 </script>

--- a/pages/backgrounds/[id].vue
+++ b/pages/backgrounds/[id].vue
@@ -1,40 +1,21 @@
 <template>
   <main v-if="background" class="docs-container container">
     <section>
-      <h1>{{ background.name }}</h1>
-      <source-tag
-        :title="background.document__slug"
-        :text="background.document__slug"
-      />
+      <div>
+        <h1 class="inline">{{ background.name }}</h1>
+        <source-tag
+          :title="background.document.name"
+          :text="background.document.name"
+        />
+      </div>
       <md-viewer :text="background.desc" />
     </section>
-    <section>
-      <p>
-        <b>Skill Proficiencies: </b>
-        <span> {{ background.skill_proficiencies }}</span>
-      </p>
-      <p v-if="background.tool_proficiencies">
-        <b>Tool Proficiencies: </b>
-        <span> {{ background.tool_proficiencies }}</span>
-      </p>
-      <p v-if="background.languages">
-        <b>Languages: </b>
-        <span> {{ background.languages }}</span>
-      </p>
-      <p>
-        <b>Equipment: </b>
-        <span> {{ background.equipment }}</span>
-      </p>
-    </section>
-    <section>
-      <h2>Feature: {{ background.feature }}</h2>
-      <md-viewer :text="background.feature_desc" />
-    </section>
-
-    <section>
-      <h2>Suggested Characteristics</h2>
-      <md-viewer :text="background.suggested_characteristics" />
-    </section>
+    <ul>
+      <li v-for="benefit in background.benefits" :key="benefit.name">
+        <h2>{{ benefit.name }}</h2>
+        <md-viewer :text="benefit.desc" />
+      </li>
+    </ul>
   </main>
   <p v-else>Loading...</p>
 </template>

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -6,7 +6,14 @@
     <api-results-table
       endpoint="backgrounds"
       :api-endpoint="API_ENDPOINTS.backgrounds"
-      :cols="['document__title', 'document__slug']"
+      :cols="[
+        {
+          displayName: 'Name',
+          value: (data) => data.name,
+          sortValue: 'name',
+          link: (data) => `/backgrounds/${data.key}`,
+        },
+      ]"
     />
   </section>
 </template>


### PR DESCRIPTION
Closes #567 

This PR changes the `/background` and `/background/[id]` to pull their data V2 of the Open5e API. Things appear to be working well, I have some notes;

1) The `/background/[id]` page could probably use so further work to arrange background features in a more aesthetically pleasing order.
2) The `/background` page looks quite sparse. The API results table contains only one column, the name of the background. Perhaps we could take the first sentence of the background description and slap it into the next column?
3) Links to backgrounds generated on the `/search` route are currently busted, they link to the V1 slugs
4) Unit tests on `/backgrounds` and `/backgrounds/[id]` are currently failing. This is because these tests mock data from V1 of the API. These need to be updated at some point (issue #566)