### PR TITLE
ESLint: turn off `curly` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,7 +23,7 @@ module.exports = {
   // add your custom rules here
   rules: {
     eqeqeq: 'off',
-    curly: 'error',
+    // curly: 'error',
     // sometimes you need to use double quotes. ie. string contains apostrophes
     // quotes: ['error', 'single'],
     'vue/multi-word-component-names': 'off',


### PR DESCRIPTION
This PR updates the Open5e ESLint rules to permit single-line conditionals that omit curly paratheses. This is should help keep our pages and components neat and tidy, especially as we begin to use TypeScript more on the frontend.

This is how we would currently have to write a guard-clause to avoid being screamed at by the linter.
```
if (!data) {
  return
}
```

However, it is much more common (and concise) to see guard-clauses written like this:
```
if (!data) return
```
