### PR TITLE
Refactor: move data fetching from `ApiResultsTable` component to page

### DIFF
--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -1,17 +1,6 @@
 <template>
   <div>
-    <div class="flex w-full flex-wrap justify-end align-middle">
-      <api-table-nav
-        :page-number="pageNo"
-        :last-page-number="lastPageNo"
-        @first="firstPage()"
-        @next="nextPage()"
-        @prev="prevPage()"
-        @last="lastPage()"
-      />
-    </div>
-
-    <table v-if="results" class="m-0 w-full">
+    <table v-if="data" class="m-0 w-full">
       <thead>
         <tr>
           <sortable-table-header
@@ -21,7 +10,7 @@
             :sort-by="col.sortValue"
             :is-sorting-property="sortBy === col.sortValue"
             :is-sort-descending="isSortDescending"
-            @sort="(sortValue) => updateSortState(sortValue)"
+            @sort="onSort(col.sortValue)"
           />
         </tr>
       </thead>
@@ -45,66 +34,22 @@
         </tr>
       </tbody>
     </table>
-    <div class="flex w-full flex-wrap justify-end align-middle">
-      <div
-        v-show="results && results.length > 0"
-        class="flex w-full justify-start italic text-blood md:w-1/2"
-      >
-        Page {{ pageNo }} of {{ lastPageNo }}
-      </div>
-      <api-table-nav
-        :page-number="pageNo"
-        :last-page-number="lastPageNo"
-        @first="firstPage()"
-        @next="nextPage()"
-        @prev="prevPage()"
-        @last="lastPage()"
-      />
-    </div>
   </div>
 </template>
 
 <script setup>
-const sortBy = ref('name');
-const isSortDescending = ref(false);
+const emit = defineEmits(['sort']);
 
 const props = defineProps({
+  data: { type: Object, default: () => {} },
   endpoint: { type: String, required: true },
-  apiEndpoint: { type: String, required: true },
   itemsPerPage: { type: Number, default: 50 },
-  fields: { type: Array, default: () => [] },
   cols: { type: Array, default: () => [] },
-  params: { type: Object, default: () => {} },
+  sortBy: { type: String, default: 'name' },
+  isSortDescending: { type: Boolean },
 });
 
-const filter = defineModel({ default: () => ({}), type: Object });
+const results = computed(() => props.data);
 
-const { data, paginator } = useFindPaginated({
-  endpoint: props.apiEndpoint,
-  itemsPerPage: props.itemsPerPage,
-  sortByProperty: sortBy,
-  isSortDescending: isSortDescending,
-  filter: filter,
-  params: {
-    ...props.params,
-    fields: ['key', 'name', 'document'].concat(props.fields).join(),
-    depth: 1,
-  },
-});
-
-const { pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
-  paginator;
-
-const results = computed(() => data.value?.results);
-const updateSortState = (property) => {
-  const column = props.cols.find((col) => col.displayName === property) || {
-    sortValue: property,
-  };
-  if (column.sortValue !== sortBy.value) {
-    sortBy.value = column.sortValue;
-    isSortDescending.value = false;
-  } else {
-    isSortDescending.value = !isSortDescending.value;
-  }
-};
+const onSort = (sortValue) => emit('sort', sortValue);
 </script>

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -79,19 +79,21 @@ const props = defineProps({
 
 const filter = defineModel({ default: () => ({}), type: Object });
 
-const { data, pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
-  useFindPaginated({
-    endpoint: props.apiEndpoint,
-    itemsPerPage: props.itemsPerPage,
-    sortByProperty: sortBy,
-    isSortDescending: isSortDescending,
-    filter: filter,
-    params: {
-      ...props.params,
-      fields: ['key', 'name', 'document'].concat(props.fields).join(),
-      depth: 1,
-    },
-  });
+const { data, paginator } = useFindPaginated({
+  endpoint: props.apiEndpoint,
+  itemsPerPage: props.itemsPerPage,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending,
+  filter: filter,
+  params: {
+    ...props.params,
+    fields: ['key', 'name', 'document'].concat(props.fields).join(),
+    depth: 1,
+  },
+});
+
+const { pageNo, firstPage, prevPage, nextPage, lastPage, lastPageNo } =
+  paginator;
 
 const results = computed(() => data.value?.results);
 const updateSortState = (property) => {

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -1,49 +1,28 @@
 <template>
-  <div class="flex w-full justify-end md:w-1/2">
-    <button
-      :disabled="isFirstPage"
-      :class="
-        isFirstPage
-          ? 'mt-1 rounded-md border-2 bg-slate-800 p-1 pl-2 text-fog'
-          : 'mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood'
-      "
-      @click="firstPage()"
-    >
-      <Icon name="heroicons:chevron-double-left" class="mr-1" />
-    </button>
-    <button
-      :disabled="isFirstPage"
-      :class="
-        isFirstPage
-          ? 'mt-1 rounded-md border-2 bg-slate-800 p-1 pl-2 text-fog'
-          : 'mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood'
-      "
-      @click="prevPage()"
-    >
-      <Icon name="heroicons:chevron-left" class="mr-1" />
-    </button>
-    <button
-      :disabled="isLastPage"
-      :class="
-        isLastPage
-          ? 'mt-1 rounded-md border-2 bg-slate-800 p-1 pl-2 text-fog'
-          : 'mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood'
-      "
-      @click="nextPage()"
-    >
-      <Icon name="heroicons:chevron-right" class="mr-1" />
-    </button>
-    <button
-      :disabled="isLastPage"
-      :class="
-        isLastPage
-          ? 'mt-1 rounded-md border-2 bg-slate-800 p-1 pl-2 text-fog'
-          : 'mt-1 rounded-md border-2 bg-blood p-1 pl-2 text-fog hover:border-blood hover:bg-fog hover:text-blood'
-      "
-      @click="lastPage()"
-    >
-      <Icon name="heroicons:chevron-double-right" class="mr-1" />
-    </button>
+  <div class="grid w-full justify-end">
+    <ul class="flex">
+      <li
+        v-for="button in buttons"
+        :key="button.name"
+        :aria-roledescription="button.name"
+      >
+        <button
+          class="mt-1 rounded-md border-2 px-2 py-1 text-fog"
+          :class="
+            button.isActive.value
+              ? 'bg-blood hover:bg-fog hover:text-blood'
+              : 'bg-slate-800'
+          "
+          @click="button.onClick()"
+        >
+          <span class="sr-only">{{ button.name }}</span>
+          <icon :name="button.icon" />
+        </button>
+      </li>
+    </ul>
+    <label class="block text-center font-bold">
+      {{ `${pageNumber} of ${lastPageNumber}` }}
+    </label>
   </div>
 </template>
 <script setup>
@@ -53,19 +32,33 @@ const props = defineProps({
 });
 const emit = defineEmits(['first', 'last', 'next', 'prev']);
 
-const isFirstPage = computed(() => props.pageNumber <= 1);
-const isLastPage = computed(() => props.pageNumber >= props.lastPageNumber);
+const isNotFirstPage = computed(() => props.pageNumber > 1);
+const isNotLastPage = computed(() => props.pageNumber < props.lastPageNumber);
 
-function firstPage() {
-  emit('first');
-}
-function lastPage() {
-  emit('last');
-}
-function nextPage() {
-  emit('next');
-}
-function prevPage() {
-  emit('prev');
-}
+const buttons = [
+  {
+    name: 'To first page',
+    isActive: isNotFirstPage,
+    onClick: () => emit('first'),
+    icon: 'heroicons:chevron-double-left',
+  },
+  {
+    name: 'Previous Page',
+    isActive: isNotFirstPage,
+    onClick: () => emit('prev'),
+    icon: 'heroicons:chevron-left',
+  },
+  {
+    name: 'Next Page',
+    isActive: isNotLastPage,
+    onClick: () => emit('next'),
+    icon: 'heroicons:chevron-right',
+  },
+  {
+    name: 'To Last page',
+    isActive: isNotLastPage,
+    onClick: () => emit('last'),
+    icon: 'heroicons:chevron-double-right',
+  },
+];
 </script>

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -1,18 +1,16 @@
 <template>
   <div class="grid w-full justify-end">
     <ul class="flex">
-      <li
-        v-for="button in buttons"
-        :key="button.name"
-        :aria-roledescription="button.name"
-      >
+      <li v-for="button in buttons" :key="button.name">
         <button
           class="mt-1 rounded-md border-2 px-2 py-1 text-fog"
+          :disabled="!button.isActive.value"
           :class="
             button.isActive.value
               ? 'bg-blood hover:bg-fog hover:text-blood'
               : 'bg-slate-800'
           "
+          :aria-roledescription="button.name"
           @click="button.onClick()"
         >
           <span class="sr-only">{{ button.name }}</span>
@@ -32,6 +30,7 @@ const props = defineProps({
 });
 const emit = defineEmits(['first', 'last', 'next', 'prev']);
 
+// conditional properties control whenever certain buttons are enabled
 const isNotFirstPage = computed(() => props.pageNumber > 1);
 const isNotLastPage = computed(() => props.pageNumber < props.lastPageNumber);
 

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
 import axios from 'axios';
 
 export const API_ENDPOINTS = {
@@ -111,98 +111,6 @@ export const useFindMany = (
         findMany(unref(endpoint), unref(sourcesForAPIVersion), unref(params))
       ),
   });
-};
-
-export const useFindPaginated = (options: {
-  endpoint: MaybeRef<string>;
-  itemsPerPage?: MaybeRef<number>;
-  initialPage?: MaybeRef<number>;
-  sortByProperty?: MaybeRef<string>;
-  isSortDescending?: MaybeRef<boolean>;
-  filter?: MaybeRef<Record<string, any>>;
-  params?: MaybeRef<Record<string, any>>;
-}) => {
-  const {
-    endpoint,
-    itemsPerPage = 50,
-    initialPage = 1,
-    sortByProperty = 'name',
-    isSortDescending = false,
-    filter = {},
-    params = {},
-  } = options;
-  const pageNo = ref(unref(initialPage));
-  const { findPaginated } = useAPI();
-  const { sources, sourcesAPIVersion1 } = useSourcesList();
-  const sourcesForAPIVersion = isV1Endpoint(unref(endpoint))
-    ? sourcesAPIVersion1
-    : sources;
-
-  const { data, isFetching, error } = useQuery({
-    queryKey: [
-      'findPaginated',
-      endpoint,
-      sourcesForAPIVersion,
-      itemsPerPage,
-      pageNo,
-      sortByProperty,
-      isSortDescending,
-      filter,
-      params,
-    ],
-    placeholderData: keepPreviousData,
-    queryFn: () =>
-      findPaginated({
-        endpoint: unref(endpoint),
-        sources: unref(sourcesForAPIVersion),
-        pageNo: unref(pageNo),
-        sortByProperty: unref(sortByProperty),
-        isSortDescending: unref(isSortDescending),
-        itemsPerPage: unref(itemsPerPage),
-        queryParams: { ...unref(params), ...unref(filter) },
-      }),
-  });
-
-  const lastPageNo = computed(() => {
-    return data.value ? Math.ceil(data.value.count / unref(itemsPerPage)) : 1;
-  });
-
-  const nextPage = () => {
-    pageNo.value++;
-  };
-
-  const prevPage = () => {
-    if (pageNo.value > 1) {
-      pageNo.value--;
-    }
-  };
-
-  const firstPage = () => {
-    pageNo.value = 1;
-  };
-
-  const lastPage = () => {
-    if (data.value) {
-      pageNo.value = lastPageNo.value;
-    }
-  };
-
-  // Move to the first page when the filter changes, to avoid showing an empty page due to fewer results
-  watch(filter, () => {
-    firstPage();
-  });
-
-  return {
-    data,
-    isFetching,
-    error,
-    firstPage,
-    prevPage,
-    nextPage,
-    lastPage,
-    pageNo,
-    lastPageNo,
-  };
 };
 
 /**

--- a/composables/useFindPaginated.ts
+++ b/composables/useFindPaginated.ts
@@ -1,3 +1,8 @@
+/* useFindPaginated handles paginated queries to the Open5e API. It will return
+ * one page of data at a time, handling refetching as query parameters change.
+ * It also returns a 'paginator' obj, which contains methods for changing the
+ * requested page */
+
 import { keepPreviousData, useQuery } from '@tanstack/vue-query';
 
 export const useFindPaginated = (options: {
@@ -20,6 +25,8 @@ export const useFindPaginated = (options: {
   } = options;
   const pageNo = ref(unref(initialPage));
   const { findPaginated } = useAPI();
+
+  // map V2 source keys to V1 source slugs if necessary
   const { sources, sourcesAPIVersion1 } = useSourcesList();
   const sourcesForAPIVersion = isV1Endpoint(unref(endpoint))
     ? sourcesAPIVersion1

--- a/composables/useFindPaginated.ts
+++ b/composables/useFindPaginated.ts
@@ -1,0 +1,95 @@
+import { keepPreviousData, useQuery } from '@tanstack/vue-query';
+
+export const useFindPaginated = (options: {
+  endpoint: MaybeRef<string>;
+  itemsPerPage?: MaybeRef<number>;
+  initialPage?: MaybeRef<number>;
+  sortByProperty?: MaybeRef<string>;
+  isSortDescending?: MaybeRef<boolean>;
+  filter?: MaybeRef<Record<string, any>>;
+  params?: MaybeRef<Record<string, any>>;
+}) => {
+  const {
+    endpoint,
+    itemsPerPage = 50,
+    initialPage = 1,
+    sortByProperty = 'name',
+    isSortDescending = false,
+    filter = {},
+    params = {},
+  } = options;
+  const pageNo = ref(unref(initialPage));
+  const { findPaginated } = useAPI();
+  const { sources, sourcesAPIVersion1 } = useSourcesList();
+  const sourcesForAPIVersion = isV1Endpoint(unref(endpoint))
+    ? sourcesAPIVersion1
+    : sources;
+
+  const { data, isFetching, error } = useQuery({
+    queryKey: [
+      'findPaginated',
+      endpoint,
+      sourcesForAPIVersion,
+      itemsPerPage,
+      pageNo,
+      sortByProperty,
+      isSortDescending,
+      filter,
+      params,
+    ],
+    placeholderData: keepPreviousData,
+    queryFn: () =>
+      findPaginated({
+        endpoint: unref(endpoint),
+        sources: unref(sourcesForAPIVersion),
+        pageNo: unref(pageNo),
+        sortByProperty: unref(sortByProperty),
+        isSortDescending: unref(isSortDescending),
+        itemsPerPage: unref(itemsPerPage),
+        queryParams: { ...unref(params), ...unref(filter) },
+      }),
+  });
+
+  const lastPageNo = computed(() => {
+    return data.value ? Math.ceil(data.value.count / unref(itemsPerPage)) : 1;
+  });
+
+  const nextPage = () => {
+    pageNo.value++;
+  };
+
+  const prevPage = () => {
+    if (pageNo.value > 1) {
+      pageNo.value--;
+    }
+  };
+
+  const firstPage = () => {
+    pageNo.value = 1;
+  };
+
+  const lastPage = () => {
+    if (data.value) {
+      pageNo.value = lastPageNo.value;
+    }
+  };
+
+  // Move to the first page when the filter changes, to avoid showing an empty page due to fewer results
+  watch(filter, () => {
+    firstPage();
+  });
+
+  return {
+    data,
+    paginator: {
+      isFetching,
+      error,
+      firstPage,
+      prevPage,
+      nextPage,
+      lastPage,
+      pageNo,
+      lastPageNo,
+    },
+  };
+};

--- a/composables/useSortState.ts
+++ b/composables/useSortState.ts
@@ -1,9 +1,15 @@
-// This composable is designed to
+/* useSortState contains logic for controlling api result table sorting.
+ * Values returned are designed to interface btwn the useFindPaginated
+ * composable and the SortableTableHeader component */
 
 export const useSortState = () => {
+  // api field to sort results by
   const currentSortingProperty = ref('name');
+
+  // state controlling sort direction of results (asc. or desc.)
   const isSortDescending = ref(false);
 
+  // setter for updating sort state, handles interactions btwn sorting prop
   const setSortState = (sortBy: string) => {
     if (sortBy === currentSortingProperty.value) {
       isSortDescending.value = !isSortDescending.value;
@@ -15,7 +21,7 @@ export const useSortState = () => {
 
   return {
     sortBy: currentSortingProperty,
-    isSortDescending,
+    isSortDescending, // boolean: is sort asc. or desc.
     setSortState,
   };
 };

--- a/composables/useSortState.ts
+++ b/composables/useSortState.ts
@@ -1,0 +1,21 @@
+// This composable is designed to
+
+export const useSortState = () => {
+  const currentSortingProperty = ref('name');
+  const isSortDescending = ref(false);
+
+  const setSortState = (sortBy: string) => {
+    if (sortBy === currentSortingProperty.value) {
+      isSortDescending.value = !isSortDescending.value;
+    } else {
+      currentSortingProperty.value = sortBy;
+      isSortDescending.value = false;
+    }
+  };
+
+  return {
+    sortBy: currentSortingProperty,
+    isSortDescending,
+    setSortState,
+  };
+};

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -3,9 +3,19 @@
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Backgrounds</h1>
     </div>
+    <api-table-nav
+      class="w-full"
+      :page-number="pageNo"
+      :last-page-number="lastPageNo"
+      @first="firstPage()"
+      @next="nextPage()"
+      @prev="prevPage()"
+      @last="lastPage()"
+    />
+
     <api-results-table
+      :data="results"
       endpoint="backgrounds"
-      :api-endpoint="API_ENDPOINTS.backgrounds"
       :cols="[
         {
           displayName: 'Name',
@@ -14,10 +24,25 @@
           link: (data) => `/backgrounds/${data.key}`,
         },
       ]"
+      :sort-by="sortBy"
+      :is-sort-descending="isSortDescending"
+      @sort="(sortValue) => setSortState(sortValue)"
     />
   </section>
 </template>
 
 <script setup>
-import ApiResultsTable from '~/components/ApiResultsTable.vue';
+const { sortBy, isSortDescending, setSortState } = useSortState();
+
+const { data, paginator } = useFindPaginated({
+  endpoint: API_ENDPOINTS.backgrounds,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending,
+  params: { fields: ['name', 'key', 'document'], depth: 1 },
+});
+
+const results = computed(() => data.value?.results);
+
+const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
+  paginator;
 </script>

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -32,17 +32,19 @@
 </template>
 
 <script setup>
+// state handlers for sorting results table
 const { sortBy, isSortDescending, setSortState } = useSortState();
 
+// fetch page of data from API and pagination controls
 const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.backgrounds,
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
   params: { fields: ['name', 'key', 'document'], depth: 1 },
 });
-
 const results = computed(() => data.value?.results);
 
+// destructure pagination controls
 const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
   paginator;
 </script>

--- a/pages/classes/index.vue
+++ b/pages/classes/index.vue
@@ -32,27 +32,23 @@
 </template>
 
 <script setup>
-const emit = defineEmits(['sort']);
-
+// state handlers for sorting results table
 const { sortBy, isSortDescending, setSortState } = useSortState();
-
-const filter = defineModel({ default: () => ({}), type: Object });
 
 // Fetch a page of classes & pagination controls
 const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.classes,
   sortByProperty: sortBy,
   isSortDescending: isSortDescending ?? true,
-  filter: filter,
   params: {
     is_subclass: false,
     fields: ['key', 'name', 'document'].join(),
     depth: 1,
   },
 });
-
 const results = computed(() => data.value?.results);
 
+// destructure pagination controls
 const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
   paginator;
 </script>

--- a/pages/classes/index.vue
+++ b/pages/classes/index.vue
@@ -3,10 +3,20 @@
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Classes</h1>
     </div>
+    <div class="flex w-full flex-wrap justify-end">
+      <api-table-nav
+        :page-number="pageNo"
+        :last-page-number="lastPageNo"
+        @first="firstPage()"
+        @next="nextPage()"
+        @prev="prevPage()"
+        @last="lastPage()"
+      />
+    </div>
+
     <api-results-table
       endpoint="classes"
-      :api-endpoint="API_ENDPOINTS.classes"
-      :params="{ is_subclass: false }"
+      :data="results"
       :cols="[
         {
           displayName: 'Class',
@@ -15,10 +25,34 @@
           link: (data) => `/classes/${data.key}`,
         },
       ]"
+      :sort-by="sortBy"
+      @sort="(sortValue) => setSortState(sortValue)"
     />
   </section>
 </template>
 
 <script setup>
-import ApiResultsTable from '~/components/ApiResultsTable.vue';
+const emit = defineEmits(['sort']);
+
+const { sortBy, isSortDescending, setSortState } = useSortState();
+
+const filter = defineModel({ default: () => ({}), type: Object });
+
+// Fetch a page of classes & pagination controls
+const { data, paginator } = useFindPaginated({
+  endpoint: API_ENDPOINTS.classes,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending ?? true,
+  filter: filter,
+  params: {
+    is_subclass: false,
+    fields: ['key', 'name', 'document'].join(),
+    depth: 1,
+  },
+});
+
+const results = computed(() => data.value?.results);
+
+const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
+  paginator;
 </script>

--- a/pages/magic-items/index.vue
+++ b/pages/magic-items/index.vue
@@ -70,8 +70,10 @@
 </template>
 
 <script setup>
+// State handlers for sorting results table
 const { sortBy, isSortDescending, setSortState } = useSortState();
 
+// Set up filters
 const displayFilter = ref(false);
 const {
   filter,
@@ -82,6 +84,7 @@ const {
   update,
 } = useFilterState(DefaultMagicItemFilter);
 
+// fields to fetch from API to populate table
 const fields = [
   'key',
   'name',
@@ -91,6 +94,7 @@ const fields = [
   'requires_attunement',
 ].join(',');
 
+// fetch page of data from API and pagination controls
 const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.magicitems,
   sortByProperty: sortBy,
@@ -98,9 +102,9 @@ const { data, paginator } = useFindPaginated({
   filter: filter,
   params: { fields, is_magic_item: true, depth: 1 },
 });
-
 const results = computed(() => data.value?.results);
 
+// destructure pagination controls
 const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
   paginator;
 </script>

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -16,57 +16,54 @@
       :filter="filter"
       :update-filter="update"
     />
-    <div>
-      <div>
-        <h3
-          ref="results"
-          class="sr-only"
-          tabindex="-1"
-          @keyup.esc="focusFilter"
-        />
-      </div>
-      <api-results-table
-        v-model="debouncedFilter"
-        endpoint="monsters"
-        :api-endpoint="API_ENDPOINTS.monsters"
-        :fields="[
-          'challenge_rating_text',
-          'challenge_rating_decimal',
-          'document',
-          'type',
-          'size',
-        ]"
-        :cols="[
-          {
-            displayName: 'Name',
-            value: (data) => data.name,
-            sortValue: 'name',
-            link: (data) => `/monsters/${data.key}`,
-          },
-          {
-            displayName: 'CR',
-            value: (data) => data.challenge_rating_text,
-            sortValue: 'challenge_rating_decimal',
-          },
-          {
-            displayName: 'Type',
-            value: (data) => data.type.name,
-            sortValue: 'type',
-          },
-          {
-            displayName: 'Size',
-            value: (data) => data.size.name,
-            sortValue: 'size',
-          },
-        ]"
-      />
-    </div>
+    <api-table-nav
+      class="w-full"
+      :page-number="pageNo"
+      :last-page-number="lastPageNo"
+      @first="firstPage()"
+      @next="nextPage()"
+      @prev="prevPage()"
+      @last="lastPage()"
+    />
+    <h3 ref="results" class="sr-only" tabindex="-1" @keyup.esc="focusFilter" />
+    <api-results-table
+      v-model="debouncedFilter"
+      :data="results"
+      endpoint="monsters"
+      :cols="[
+        {
+          displayName: 'Name',
+          value: (data) => data.name,
+          sortValue: 'name',
+          link: (data) => `/monsters/${data.key}`,
+        },
+        {
+          displayName: 'CR',
+          value: (data) => data.challenge_rating_text,
+          sortValue: 'challenge_rating_decimal',
+        },
+        {
+          displayName: 'Type',
+          value: (data) => data.type.name,
+          sortValue: 'type',
+        },
+        {
+          displayName: 'Size',
+          value: (data) => data.size.name,
+          sortValue: 'size',
+        },
+      ]"
+      :sort-by="sortBy"
+      :is-sort-descending="isSortDescending"
+      @sort="(sortValue) => setSortState(sortValue)"
+    />
   </section>
 </template>
 
 <script setup>
-const displayFilter = ref(false);
+const { sortBy, isSortDescending, setSortState } = useSortState();
 
+const displayFilter = ref(false);
 const {
   filter,
   debouncedFilter,
@@ -75,4 +72,28 @@ const {
   clear,
   update,
 } = useFilterState(DefaultMonsterFilter);
+
+const fields = [
+  'key',
+  'name',
+  'document',
+  'challenge_rating_text',
+  'challenge_rating_decimal',
+  'document',
+  'type',
+  'size',
+].join(',');
+
+const { data, paginator } = useFindPaginated({
+  endpoint: API_ENDPOINTS.monsters,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending,
+  filter: filter,
+  params: { fields, is_subclass: false, depth: 1 },
+});
+
+const results = computed(() => data.value?.results);
+
+const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
+  paginator;
 </script>

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -64,8 +64,10 @@
 </template>
 
 <script setup>
+// State handlers for sorting results table
 const { sortBy, isSortDescending, setSortState } = useSortState();
 
+// Set up filters
 const displayFilter = ref(false);
 const {
   filter,
@@ -76,6 +78,7 @@ const {
   update,
 } = useFilterState(DefaultMonsterFilter);
 
+// fields to fetch from API to populate table
 const fields = [
   'key',
   'name',
@@ -87,6 +90,7 @@ const fields = [
   'size',
 ].join(',');
 
+// fetch page of data from API and pagination controls
 const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.monsters,
   sortByProperty: sortBy,
@@ -94,9 +98,9 @@ const { data, paginator } = useFindPaginated({
   filter: filter,
   params: { fields, is_subclass: false, depth: 1 },
 });
-
 const results = computed(() => data.value?.results);
 
+// destructure pagination controls
 const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
   paginator;
 </script>

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -10,12 +10,14 @@
         @clear-filter="clear"
       />
     </div>
+
     <monster-filter-box
       v-if="displayFilter"
       ref="monsterFilterBox"
       :filter="filter"
       :update-filter="update"
     />
+
     <api-table-nav
       class="w-full"
       :page-number="pageNo"
@@ -25,6 +27,7 @@
       @prev="prevPage()"
       @last="lastPage()"
     />
+
     <h3 ref="results" class="sr-only" tabindex="-1" @keyup.esc="focusFilter" />
     <api-results-table
       v-model="debouncedFilter"

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -51,8 +51,10 @@
 </template>
 
 <script setup>
+// State handlers for sorting results table
 const { sortBy, isSortDescending, setSortState } = useSortState();
 
+// fields to fetch from API to populate table
 const fields = [
   'name',
   'level',

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -3,19 +3,19 @@
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Spells</h1>
     </div>
+
+    <api-table-nav
+      :page-number="pageNo"
+      :last-page-number="lastPageNo"
+      @first="firstPage()"
+      @next="nextPage()"
+      @prev="prevPage()"
+      @last="lastPage()"
+    />
+
     <api-results-table
+      :data="results"
       endpoint="spells"
-      :api-endpoint="API_ENDPOINTS.spells"
-      :fields="[
-        'name',
-        'level',
-        'school',
-        'verbal',
-        'material',
-        'material_consumed',
-        'somatic',
-        'concentration',
-      ]"
       :cols="[
         {
           displayName: 'Name',
@@ -35,28 +35,51 @@
         },
         {
           displayName: 'Components',
-          value: (data) =>
-            formatComponents(
-              data.verbal,
-              data.somatic,
-              data.material,
-              data.material_consumed
-            ),
-        }, // I know this is super ugly but my brain is tired and it works
+          value: (data) => formatComponents(data),
+        },
         {
           displayName: 'Concentration',
-          value: (data) => `${data.concentration ? 'yes' : ''}`,
+          value: (data) => (data.concentration ? '√' : '-'),
           sortValue: 'concentration',
         },
       ]"
+      :sort-by="sortBy"
+      :is-sort-descending="isSortDescending"
+      @sort="(sortValue) => setSortState(sortValue)"
     />
   </section>
 </template>
 
 <script setup>
-import ApiResultsTable from '~/components/ApiResultsTable.vue';
+const { sortBy, isSortDescending, setSortState } = useSortState();
 
-function formatComponents(verbal, somatic, material, material_consumed) {
+const fields = [
+  'name',
+  'level',
+  'school',
+  'verbal',
+  'material',
+  'material_consumed',
+  'somatic',
+  'concentration',
+];
+
+// Fetch a page of results and pagination controls
+const { data, paginator } = useFindPaginated({
+  endpoint: API_ENDPOINTS.spells,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending,
+  params: { fields, depth: 1 },
+});
+const results = computed(() => data.value?.results);
+
+// destructure pagination controls
+const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
+  paginator;
+
+// helper function for formatting spell components
+const formatComponents = (data) => {
+  const { verbal, somatic, material, material_consumed: consumed } = data;
   let components = [];
   if (verbal) {
     components.push('V');
@@ -65,8 +88,8 @@ function formatComponents(verbal, somatic, material, material_consumed) {
     components.push('S');
   }
   if (material) {
-    components.push('M');
+    components.push(consumed ? 'M*' : 'M');
   }
-  return `${components.join(', ')}${material_consumed ? '*' : ''}`;
-}
+  return components.join(', ');
+};
 </script>


### PR DESCRIPTION
I encountered an issue while exploring migrating testing to work with V2 of the API: data fetching was not actually taking place on the top-level page components, but nested inside the `ApiResultsTable` component. It was an absolute headache getting this component to play nice with our testing suite, a clear indicator that a refactor was due.

This PR refactors much of the logic contained in `ApiResultsTable` so that it better follows principals single-responsibility (it is now long responsible everything on the page; data fetching, pagination, rendering the UI, &c) and interface segregation (UI components nested within `ApiResultsTable` are now called at the page level, permitting simpler control over UI design and layout)

1) Moving data fetch via `useFindPaginated()` to the page component script
2) Moving deeply nested UI to the page component template
3) Refactoring sorting logic into `useSortState()` composable

With this in place it should now be possible to correctly mock test data for our by page unit tests. Working with the pages and components that this PR has touch should now be a lot simpler