### PR TITLE
Feature: V2 Races

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -96,6 +96,7 @@ table {
   }
   p,
   ul,
+  dt,
   hr,
   h1,
   h2,

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -19,7 +19,7 @@ const props = defineProps({
   toc: { type: Boolean, default: true },
   text: { type: String, default: 'loading...' },
   headerLevel: { type: Number, default: 1 },
-  inline: { type: Boolean, default: false },
+  inline: { type: Boolean },
   useRoller: { type: Boolean, default: false },
 });
 
@@ -47,7 +47,7 @@ const extensions = computed(() => {
 <style>
 .markdown-inline {
   display: inline;
-  * {
+  :not(table, th, td, tr, thead, tbody) {
     display: inherit;
   }
 }

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -10,7 +10,7 @@ export const API_ENDPOINTS = {
   feats: 'v1/feats/',
   magicitems: 'v2/items/',
   monsters: 'v2/creatures/',
-  races: 'v1/races/',
+  races: 'v2/races/',
   search: 'v2/search/',
   sections: 'v1/sections/',
   spells: 'v2/spells/',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -167,9 +167,6 @@ const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
   fields: ['name', 'key'].join(),
   is_subclass: false,
 });
-const { data: races } = useFindMany(API_ENDPOINTS.races, {
-  fields: ['name', 'slug'].join(),
-});
 const { data: combat_sections } = useSections('Combat');
 const { data: equipment_sections } = useSections('Equipment');
 const { data: gameplay_sections } = useSections('Gameplay Mechanics');
@@ -186,41 +183,8 @@ const isLoadingData = useIsFetching();
 
 const routes = computed(() => [
   {
-    title: 'Characters',
-    route: '/characters',
-    subroutes: character_sections.value ?? [],
-  },
-  {
-    title: 'Classes',
-    route: '/classes',
-    subroutes: classes.value ?? [],
-  },
-  {
-    title: 'Conditions',
-    route: '/conditions',
-  },
-  {
-    title: 'Races',
-    route: '/races',
-    subroutes: races.value ?? [],
-  },
-  {
-    title: 'Backgrounds',
-    route: '/backgrounds',
-  },
-  {
-    title: 'Feats',
-    route: '/feats',
-  },
-  {
-    title: 'Combat',
-    route: '/combat',
-    subroutes: combat_sections.value ?? [],
-  },
-  {
-    title: 'Equipment',
-    route: '/equipment',
-    subroutes: equipment_sections.value ?? [],
+    title: 'Monsters',
+    route: '/monsters',
   },
   {
     title: 'Magic Items',
@@ -231,9 +195,42 @@ const routes = computed(() => [
     route: '/spells',
     subroutes: spellcastingClasses,
   },
+
   {
-    title: 'Monsters',
-    route: '/monsters',
+    title: 'Classes',
+    route: '/classes',
+    subroutes: classes.value ?? [],
+  },
+  {
+    title: 'Races',
+    route: '/races',
+  },
+  {
+    title: 'Backgrounds',
+    route: '/backgrounds',
+  },
+  {
+    title: 'Feats',
+    route: '/feats',
+  },
+  {
+    title: 'Conditions',
+    route: '/conditions',
+  },
+  {
+    title: 'Characters',
+    route: '/characters',
+    subroutes: character_sections.value ?? [],
+  },
+  {
+    title: 'Combat',
+    route: '/combat',
+    subroutes: combat_sections.value ?? [],
+  },
+  {
+    title: 'Equipment',
+    route: '/equipment',
+    subroutes: equipment_sections.value ?? [],
   },
   {
     title: 'Gameplay Mechanics',

--- a/pages/races/[id].vue
+++ b/pages/races/[id].vue
@@ -5,7 +5,9 @@
       <h2>Traits</h2>
       <div v-for="trait in traits" :key="trait.name" class="my-2">
         <dh class="font-bold after:content-['._']">{{ trait.name }}</dh>
-        <dd class="inline">{{ trait.desc }}</dd>
+        <dd class="inline">
+          <md-viewer :inline="true" :text="trait.desc" />
+        </dd>
       </div>
     </dt>
 
@@ -13,7 +15,7 @@
       <h2>Subraces</h2>
       <li v-for="subrace in subraces" :key="subrace.key">
         <h3>{{ subrace.name }}</h3>
-        <md-viewer :text="subrace.desc" />
+        <md-viewer :inline="true" :text="subrace.desc" />
         <dt>
           <div v-for="trait in subrace.traits" :key="trait.name" class="my-2">
             <dh class="font-bold after:content-['._']">{{ trait.name }}</dh>

--- a/pages/races/[id].vue
+++ b/pages/races/[id].vue
@@ -1,48 +1,39 @@
 <template>
   <section v-if="race" class="docs-container container">
     <h1>{{ race.name }}</h1>
-    <md-viewer :text="race.desc" />
-    <md-viewer :text="race['asi_desc']" />
-    <md-viewer :text="race['speed_desc']" />
-    <md-viewer :text="race.vision" />
-    <md-viewer :text="race.age" />
-    <md-viewer :text="race.alignment" />
-    <md-viewer :text="race.size" />
-    <md-viewer :text="race.languages" />
-    <md-viewer :text="race.traits" />
-    <p class="text-sm italic">
-      Source:
-      <a target="NONE" :href="race.document__url">
-        <span>{{ race.document__title }}</span>
-        <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
-      </a>
-    </p>
+    <dt>
+      <h2>Traits</h2>
+      <div v-for="trait in traits" :key="trait.name" class="my-2">
+        <dh class="font-bold after:content-['._']">{{ trait.name }}</dh>
+        <dd class="inline">{{ trait.desc }}</dd>
+      </div>
+    </dt>
 
-    <h2 v-if="subraceLength > 0">Subraces</h2>
-    <div v-for="subrace in race.subraces" :key="subrace.name">
-      <h3 class="flex items-center">
-        {{ subrace.name }}
-        <source-tag
-          v-show="race.document__slug"
-          class="ml-4"
-          :title="race.document__title"
-          :text="race.document__slug"
-        />
-      </h3>
-      <md-viewer :header-level="2" :text="subrace.desc" />
-      <md-viewer :text="subrace['asi_desc']" />
-      <md-viewer :text="subrace.traits" />
-      <p class="text-sm italic">
-        Source:
-        <a target="NONE" :href="subrace.document__url">
-          {{ subrace.document__title }}
-          <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
-        </a>
-      </p>
-    </div>
+    <ul v-if="Object.keys(subraces).length > 0">
+      <h2>Subraces</h2>
+      <li v-for="subrace in subraces" :key="subrace.key">
+        <h3>{{ subrace.name }}</h3>
+        <md-viewer :text="subrace.desc" />
+        <dt>
+          <div v-for="trait in subrace.traits" :key="trait.name" class="my-2">
+            <dh class="font-bold after:content-['._']">{{ trait.name }}</dh>
+            <dd class="inline">{{ trait.desc }}</dd>
+          </div>
+        </dt>
+      </li>
+    </ul>
   </section>
 </template>
 
 <script setup>
-const { data: race } = useFindOne(API_ENDPOINTS.races, useRoute().params.id);
+const { data: race } = useFindOne(API_ENDPOINTS.races, useRoute().params.id, {
+  params: { subrace_of__isnull: true },
+});
+
+const { data: subraces } = useFindMany(API_ENDPOINTS.races, {
+  subrace_of__key__in: useRoute().params.id,
+});
+
+// traits can be ordered here, but the order the API rtns them is already good
+const traits = computed(() => unref(race).traits);
 </script>

--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -12,6 +12,7 @@
       @prev="prevPage()"
       @last="lastPage()"
     />
+
     <api-results-table
       :data="results"
       :cols="[
@@ -21,6 +22,9 @@
           link: (data) => `/races/${data.key}`,
         },
       ]"
+      :sort-by="sortBy"
+      :is-sort-descending="isSortDescending"
+      @sort="(sortValue) => setSortState(sortValue)"
     />
   </section>
 </template>

--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -3,14 +3,44 @@
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Races</h1>
     </div>
+
+    <api-table-nav
+      :page-number="pageNo"
+      :last-page-number="lastPageNo"
+      @first="firstPage()"
+      @next="nextPage()"
+      @prev="prevPage()"
+      @last="lastPage()"
+    />
     <api-results-table
-      endpoint="races"
-      :api-endpoint="API_ENDPOINTS.races"
-      :cols="['document__title', 'document__slug']"
+      :data="results"
+      :cols="[
+        {
+          displayName: 'Name',
+          value: (data) => data.name,
+          link: (data) => `/races/${data.key}`,
+        },
+      ]"
     />
   </section>
 </template>
 
 <script setup>
-import ApiResultsTable from '~/components/ApiResultsTable.vue';
+const { sortBy, isSortDescending, setSortState } = useSortState();
+
+// fetch page of data from API and pagination controls
+const { data, paginator } = useFindPaginated({
+  endpoint: API_ENDPOINTS.races,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending,
+  params: {
+    fields: ['name', 'key', 'document'].join(','),
+    subrace_of__isnull: true,
+    depth: 1,
+  },
+});
+const results = computed(() => data.value?.results);
+
+const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
+  paginator;
 </script>


### PR DESCRIPTION
This PR refactors the `/races` and `/races/[id]` routes to pull their data from V2 of the Open5e API.

These changes follow a pattern established by the other endpoint, not much more to add that hasn't been covered in previous PRs!