### PR TITLE
Feature: Feats V2

### DIFF
--- a/composables/api.ts
+++ b/composables/api.ts
@@ -7,7 +7,7 @@ export const API_ENDPOINTS = {
   classes: 'v2/classes/',
   conditions: 'v1/conditions/',
   documents: 'v2/documents/',
-  feats: 'v1/feats/',
+  feats: 'v2/feats/',
   magicitems: 'v2/items/',
   monsters: 'v2/creatures/',
   races: 'v2/races/',

--- a/pages/feats/[id].vue
+++ b/pages/feats/[id].vue
@@ -2,27 +2,31 @@
   <main v-if="feat" class="docs-container container">
     <h1>
       <span>{{ feat.name }}</span>
-      <source-tag
-        v-if="feat.document__slug !== 'wotc-srd'"
-        :text="feat.document__slug"
-        :title="feat.document__title"
-      />
+      <source-tag :text="sourceKey" :title="feat.document.name" />
     </h1>
     <section>
       <p v-if="feat.prerequisite">
-        <b>{{ feat.prerequisite }}</b>
+        <span class="font-bold after:content-['._']">Prerequistes</span>
+        <span>{{ feat.prerequisite }}</span>
       </p>
-      <md-viewer :text="feat.desc" />
-      <ul v-if="feat.effects_desc.length > 0">
-        <li v-for="point in feat.effects_desc" :key="point.slice(0, 10)">
-          {{ point }}
-        </li>
-      </ul>
+      <md-viewer :text="feat.desc" class="list-disc" />
     </section>
   </main>
   <p v-else>Loading...</p>
 </template>
 
 <script setup>
-const { data: feat } = useFindOne(API_ENDPOINTS.feats, useRoute().params.id);
+const { data: feat } = useFindOne(API_ENDPOINTS.feats, useRoute().params.id, {
+  fields: ['name', 'desc', 'prerequisite', 'document'],
+});
+
+// generate source key from page URL - for use with source-tab cmpnt
+const sourceKey = computed(
+  () =>
+    useRoute()
+      .params.id.split('/')
+      .filter((exists) => exists)
+      .pop()
+      .split('_')[0]
+);
 </script>

--- a/pages/feats/index.vue
+++ b/pages/feats/index.vue
@@ -3,14 +3,45 @@
     <div class="filter-header-wrapper">
       <h1 class="filter-header">Feats</h1>
     </div>
+
+    <api-table-nav
+      class="w-full"
+      :page-number="pageNo"
+      :last-page-number="lastPageNo"
+      @first="firstPage()"
+      @next="nextPage()"
+      @prev="prevPage()"
+      @last="lastPage()"
+    />
+
     <api-results-table
-      endpoint="feats"
-      :api-endpoint="API_ENDPOINTS.feats"
-      :cols="['document__title', 'document__slug']"
+      :data="results"
+      :cols="[
+        {
+          displayName: 'Name',
+          value: (data) => data.name,
+          sortValue: 'name',
+          link: (data) => `/feats/${data.key}`,
+        },
+      ]"
+      :sort-by="sortBy"
+      :is-sort-descending="isSortDescending"
+      @sort="(sortValue) => setSortState(sortValue)"
     />
   </section>
 </template>
 
 <script setup>
-import ApiResultsTable from '~/components/ApiResultsTable.vue';
+const { sortBy, isSortDescending, setSortState } = useSortState();
+
+// fetch page of data from API and pagination controls
+const { data, paginator } = useFindPaginated({
+  endpoint: API_ENDPOINTS.feats,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending,
+  params: { fields: ['key', 'name', 'document'].join(','), depth: 1 },
+});
+const results = computed(() => data.value?.results);
+const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
+  paginator;
 </script>


### PR DESCRIPTION
This PR updates the `/feats` and `/feats/[id]` routes to pull data from V2 of the Open5e API.

Follows a similar (identical?) pattern to several previous PRs, not much further to add to be honest!