### PR TITLE
V2 Feature: Search

### DIFF
--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -15,7 +15,10 @@
 
     <!-- Row subtitle -->
 
-    <div v-if="result.object_model === 'Creature'" class="text-sm">
+    <div
+      v-if="result.object_model === 'Creature' && result.object?.cr"
+      class="text-sm"
+    >
       <span class="after:content-['_|_']">CR {{ result.object.cr }}</span>
       <span>{{ `${result.object.type} (${result.object.size})` }}</span>
     </div>
@@ -97,6 +100,7 @@ const formatCategory = (input) => {
   const category = input.object_model.match(/[A-Z][a-z]+/g).join(' ');
   // Creatures -> Monsters
   if (category === 'Creature') return 'Monster';
+  if (input.object?.is_magic_item) return 'Magic Item';
   // Character Class -> Class OR [CLASS] Subclass
   if (category === 'Character Class') {
     if (input?.object?.subclass_of)
@@ -106,7 +110,6 @@ const formatCategory = (input) => {
   // Race -> Race OR [RACE] Subrace
   if (input?.object?.subrace_of)
     return `${input.object.subrace_of.name} Subrace`;
-
   return category; // BASE-CASE: return category without alteration
 };
 </script>

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -45,7 +45,7 @@
     <!-- include snipet if query text is not part of article title -->
     <md-viewer
       v-if="!result.object_name.toUpperCase().includes(query.toUpperCase())"
-      class="mt-['-4'] text-sm italic text-granite dark:text-granite"
+      class="text-sm italic text-granite dark:text-granite"
       :markdown="stripMarkdownTables(result.highlighted)"
     />
   </li>
@@ -65,6 +65,7 @@ function stripMarkdownTables(text) {
     .replace(/-{3,}/g, ''); // Remove three or more hyphens
 }
 
+// Look-up Table: mapping API endpoints to website routes
 const endpoints = {
   Creature: 'monsters',
   Spell: 'spells',
@@ -76,6 +77,7 @@ const endpoints = {
   CharacterClass: 'classes',
 };
 
+// Takes a search result and generates its URL on the Open5e website
 const formatUrl = (input) => {
   let baseUrl = endpoints[input.object_model] ?? input.object_model;
 
@@ -89,18 +91,23 @@ const formatUrl = (input) => {
   return `${baseUrl}/${input.object_pk}`;
 };
 
+// Takes the API endpoint a result is pulled from and returns
 const formatCategory = (input) => {
+  // Insert spaces into PascalCase text
   const category = input.object_model.match(/[A-Z][a-z]+/g).join(' ');
+  // Creatures -> Monsters
   if (category === 'Creature') return 'Monster';
+  // Character Class -> Class OR [CLASS] Subclass
   if (category === 'Character Class') {
     if (input?.object?.subclass_of)
       return `${input.object.subclass_of.name} Subclass`;
-    return 'Class';
+    else return 'Class';
   }
+  // Race -> Race OR [RACE] Subrace
   if (input?.object?.subrace_of)
     return `${input.object.subrace_of.name} Subrace`;
 
-  return category; // base-case: return category without substitutions
+  return category; // BASE-CASE: return category without alteration
 };
 </script>
 

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -276,7 +276,7 @@ export const useSearch = (queryRef: Ref<string>) => {
     queryFn: () =>
       queryRef.value
         ? findMany(`${API_ENDPOINTS.search}`, [], {
-            schema: 'v1',
+            schema: 'v2',
             query: queryRef.value,
           })
         : [],

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -275,7 +275,7 @@ export const useSearch = (queryRef: Ref<string>) => {
     queryKey: ['search', queryRef],
     queryFn: () =>
       queryRef.value
-        ? findMany(`${API_ENDPOINTS.search}`, [], {
+        ? findMany(API_ENDPOINTS.search, [], {
             schema: 'v2',
             query: queryRef.value,
           })

--- a/composables/spells.ts
+++ b/composables/spells.ts
@@ -52,3 +52,17 @@ const SPELL_LEVELS_NAMES = [
   '8th-level',
   '9th-level',
 ] as const;
+
+interface IUseFormatSpellSubtitle {
+  level: number | undefined;
+  school: string | undefined;
+}
+export const useFormatSpellSubtitle = ({
+  level,
+  school,
+}: IUseFormatSpellSubtitle) => {
+  const spellType = `${school} ${level && level > 0 ? 'Spell' : 'Cantrip'}`;
+  if (!level) return spellType;
+  const spellLevel = level > 0 ? SPELL_LEVELS_NAMES[level] + ' ' : '';
+  return spellLevel + spellType;
+};

--- a/composables/spells.ts
+++ b/composables/spells.ts
@@ -53,6 +53,10 @@ const SPELL_LEVELS_NAMES = [
   '9th-level',
 ] as const;
 
+/** useFormatSpellSubtitle takes a spells school and name and returns a user
+ * readble formatted string.
+ */
+
 interface IUseFormatSpellSubtitle {
   level: number | undefined;
   school: string | undefined;
@@ -61,8 +65,9 @@ export const useFormatSpellSubtitle = ({
   level,
   school,
 }: IUseFormatSpellSubtitle) => {
+  // use typeof for early rtrn because !level is false when level = 0
+  if (typeof level !== 'number') return `${school} Spell`;
   const spellType = `${school} ${level && level > 0 ? 'Spell' : 'Cantrip'}`;
-  if (!level) return spellType;
   const spellLevel = level > 0 ? SPELL_LEVELS_NAMES[level] + ' ' : '';
   return spellLevel + spellType;
 };

--- a/pages/search/index.vue
+++ b/pages/search/index.vue
@@ -52,11 +52,10 @@
 
 <script setup>
 import { computed } from 'vue';
-import SearchResult from '~/components/SearchResult';
 
 const searchText = useQueryParam('text');
 const { data } = useSearch(searchText);
-const { sourcesAPIVersion1: sources } = useSourcesList();
+const { sources } = useSourcesList();
 
 const results = computed(() => {
   if (!data || !data.value) {


### PR DESCRIPTION
This PR closes #581 by updating the `/search` page to correctly to parse links using V2 API article keys.

Working through this issue surfaced several point where critical information wasn't returned by the API. I fixed these issue as I encountered them, and have created a [PR on the backend repo containing all these fixes](https://github.com/open5e/open5e-api/pull/535). While 95% of this PR works perfectly with the current version of the API on the `staging` branch (everything except subraces and subclasses), the final 5% depends on these changes