### PR TITLE
API V2: Rulesets

### DIFF
--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -16,11 +16,12 @@
           >
             <option>–</option>
             <option
-              v-for="ruleset in allRulesets"
-              :key="ruleset"
-              :value="ruleset"
+              v-for="rulesetOption in allRulesets"
+              :key="rulesetOption"
+              :value="rulesetOption"
+              :selected="rulesetOption === currentRuleset"
             >
-              {{ ruleset }}
+              {{ rulesetOption }}
             </option>
           </select>
         </div>
@@ -146,7 +147,7 @@
 </template>
 
 <script setup>
-const { sources, setSources } = useSourcesList();
+const { sources, setSources, ruleset, setRuleset } = useSourcesList();
 
 const emit = defineEmits(['close']);
 const closeModal = () => emit('close');
@@ -165,7 +166,7 @@ const groupedDocuments = computed(() => {
   }, {});
 });
 
-const currentRuleset = ref(undefined);
+const currentRuleset = ruleset;
 
 // returns the names of all rulesets present in API data
 const allRulesets = computed(() => {
@@ -190,6 +191,7 @@ const onRulesetChanged = (event) => {
 
 function saveSelection() {
   setSources(selectedSources.value);
+  setRuleset(currentRuleset.value);
   closeModal();
 }
 

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -177,12 +177,11 @@ const allRulesets = computed(() => {
 });
 
 const onRulesetChanged = (event) => {
-  const ruleset = event.target.value;
-  if (allRulesets.value.includes(ruleset)) currentRuleset.value = ruleset;
-  else currentRuleset.value = '';
+  const newRuleset = event.target.value;
+  currentRuleset.value = newRuleset;
   const newSources = documents.value
     .filter(
-      (source) => !currentRuleset.value || source.ruleset.name === ruleset
+      (source) => !currentRuleset.value || source.ruleset.name === newRuleset
     )
     .map((source) => source.key);
   selectedSources.value = newSources;

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -14,7 +14,7 @@
             name="ruleset"
             @change="onRulesetChanged"
           >
-            <option>–</option>
+            <option :value="''">–</option>
             <option
               v-for="rulesetOption in allRulesets"
               :key="rulesetOption"
@@ -166,8 +166,7 @@ const groupedDocuments = computed(() => {
   }, {});
 });
 
-const currentRuleset = ruleset;
-
+const currentRuleset = ref(ruleset.value);
 // returns the names of all rulesets present in API data
 const allRulesets = computed(() => {
   return documents?.value?.reduce((rulesets, document) => {
@@ -180,7 +179,7 @@ const allRulesets = computed(() => {
 const onRulesetChanged = (event) => {
   const ruleset = event.target.value;
   if (allRulesets.value.includes(ruleset)) currentRuleset.value = ruleset;
-  else currentRuleset.value = undefined;
+  else currentRuleset.value = '';
   const newSources = documents.value
     .filter(
       (source) => !currentRuleset.value || source.ruleset.name === ruleset

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -2,8 +2,25 @@
   <modal-dialog @close="closeModal()">
     <slot>
       <!-- MODAL MENU TITLE BAR -->
-      <div class="flex w-full justify-between border-b-4 border-red-400">
-        <h2 class="mt-0 pb-2">Select Sources</h2>
+      <div class="flex w-full justify-between border-b-4 border-blood">
+        <h2 class="my-2">Sources</h2>
+
+        <!--  RULESET SELECTOR -->
+        <div class="my-1 grid">
+          <label class="font-serif text-sm">Ruleset</label>
+          <select
+            id="ruleset"
+            class="border-b-2 border-smoke bg-transparent text-sm"
+            name="ruleset"
+          >
+            <option>–</option>
+            <option v-for="ruleset in rulesets" :key="ruleset" :value="ruleset">
+              {{ ruleset }}
+            </option>
+          </select>
+        </div>
+
+        <!-- CONTROL FOR SELECTING ALL / NO SOURCES -->
         <div class="serif font-bold">
           <button
             :class="`px-2 py-1 ${
@@ -14,7 +31,7 @@
             }`"
             @click="selectAll()"
           >
-            <span>All</span>
+            All
           </button>
 
           <button
@@ -26,7 +43,7 @@
             }`"
             @click="deselectAll()"
           >
-            <span>None</span>
+            None
           </button>
         </div>
       </div>
@@ -141,9 +158,17 @@ const groupedDocuments = computed(() => {
   }, {});
 });
 
-function closeModal() {
-  emit('close'); // emits a 'close' event to the parent component
-}
+// returns the names of all rulesets present in API data
+const rulesets = computed(() => {
+  return documents?.value?.reduce((rulesets, document) => {
+    if (!rulesets.includes(document.ruleset.name)) {
+      return [...rulesets, document.ruleset.name];
+    } else return rulesets;
+  }, []);
+});
+
+const closeModal = () => emit('close');
+
 function saveSelection() {
   setSources(selectedSources.value);
   closeModal();
@@ -170,23 +195,6 @@ function removePublisher(publisher) {
   );
 }
 
-function togglePublisher(publisher) {
-  const sourcesByPublisher = groupedDocuments.value[publisher].map(
-    (source) => source.key // get slugs for sources by publisher
-  );
-
-  if (selectedSourcesByPublisher(publisher)) {
-    selectedSources.value = selectedSources.value.filter(
-      (source) => !sourcesByPublisher.includes(source)
-    );
-  } else {
-    const sourcesToAdd = sourcesByPublisher.filter(
-      (source) => !selectedSources.value.includes(source)
-    );
-    selectedSources.value = [...selectedSources.value, ...sourcesToAdd]; // combine checked & unchecked sources
-  }
-}
-
 function countSourcesByPublisher(publisher) {
   return groupedDocuments.value[publisher]?.length || 0;
 }
@@ -211,7 +219,5 @@ function selectAll() {
   selectedSources.value = documents.value.map((doc) => doc.key);
 }
 
-function deselectAll() {
-  selectedSources.value = [];
-}
+const deselectAll = () => (selectedSources.value = []);
 </script>

--- a/composables/sources.ts
+++ b/composables/sources.ts
@@ -10,6 +10,21 @@ function writeSourcesToLocalStorage(sourcesList: string[]) {
 
 const _sources = ref<string[]>(loadSourcesFromLocalStorage());
 
+const loadRulesetFromStorage = () => {
+  if (!import.meta.client) return '';
+  return localStorage.getItem('ruleset') ?? '';
+};
+
+const writeRulesetToStorage = (input: string) =>
+  localStorage.setItem('ruleset', input);
+
+const ruleset = ref<string>(loadRulesetFromStorage());
+
+const setRuleset = (input: string) => {
+  ruleset.value = input;
+  writeRulesetToStorage(input);
+};
+
 /* _sourcesV1 maps Document keys from API V2 onto their V1 equivalents. This
  * has been added so that we can move the /documents endpoint over to V2 w/o
  * breaking the seleciton by source functionality for routes pulling from V1.
@@ -47,6 +62,8 @@ export const read_only_source_list = computed(() => _sources.value);
 export const useSourcesList = () => ({
   /** List of source tags */
   sources: read_only_source_list,
+  ruleset,
+  setRuleset,
   setSources,
   sourcesAPIVersion1: _sourcesV1,
 });

--- a/composables/sources.ts
+++ b/composables/sources.ts
@@ -12,13 +12,13 @@ const _sources = ref<string[]>(loadSourcesFromLocalStorage());
 
 const loadRulesetFromStorage = () => {
   if (!import.meta.client) return '';
-  return localStorage.getItem('ruleset') ?? '';
+  return localStorage.getItem('ruleset');
 };
 
 const writeRulesetToStorage = (input: string) =>
   localStorage.setItem('ruleset', input);
 
-const ruleset = ref<string>(loadRulesetFromStorage());
+const ruleset = ref<string | null>(loadRulesetFromStorage());
 
 const setRuleset = (input: string) => {
   ruleset.value = input;


### PR DESCRIPTION
Closes #585 by adding support for filtering by ruleset in the `SourcesModal` component.

The currently selected ruleset is stored in local storage (handled by the `useSourcesList` composable) which can be used to drive logic at different points on the website. ie. If `Advanced 5e` is selected at the ruleset, then Advanced 5e classes can be linked to via the navbar, or the spells by class page can use spell lists form Advanced 5e classes.

Here is what the UI looks like:

<img width="510" alt="Screenshot 2024-09-20 at 08 17 39" src="https://github.com/user-attachments/assets/77644741-60b2-4ac5-b492-8a93c7a487a5">

<img width="514" alt="Screenshot 2024-09-20 at 08 17 53" src="https://github.com/user-attachments/assets/1f2eca64-280e-4464-9153-d77ad5250644">

<img width="512" alt="Screenshot 2024-09-20 at 08 17 47" src="https://github.com/user-attachments/assets/6b9a8d7d-bdf7-4069-800b-aab990fa90d6">
