### PR TITLE
V2 API - Fix Magic Item filterbox

### DIFF
--- a/components/MagicItemFilterBox.vue
+++ b/components/MagicItemFilterBox.vue
@@ -5,7 +5,6 @@
   >
     <div class="bg-blue flex w-full flex-wrap align-middle">
       <!-- FILTER BY ITEM NAME -->
-      <!-- TODO: filtering by name unsupported by API (2 Sep. 24) -->
       <label for="itemName" class="pt-1 font-bold md:w-1/6">ITEM NAME:</label>
       <input
         id="itemName"
@@ -17,10 +16,9 @@
       />
 
       <!-- FILTER BY MAGIC ITEM RARITY -->
-      <!-- TODO: filtering by rarity unsupported by API (2 Sep. 24) -->
       <div class="flex w-full flex-wrap">
         <div class="mt-2 flex w-full flex-wrap md:w-1/2">
-          <span class="mr-2 w-full font-bold">RARITY:</span>
+          <label class="mr-2 w-full font-bold" for="rarity">RARITY:</label>
           <select
             id="rarity"
             :value="filter.rarity"
@@ -30,38 +28,39 @@
           >
             <option :key="''" :value="''" text="Any" />
             <option
-              v-for="rtg in MAGIC_ITEMS_RARITES"
-              :key="rtg"
-              :value="rtg"
-              v-text="rtg"
+              v-for="rarity in MAGIC_ITEMS_RARITES"
+              :key="rarity"
+              :value="rarity.toLowerCase().split(' ').join('-')"
+              v-text="rarity"
             />
           </select>
         </div>
 
         <!-- FILTER BY MAGIC ITEM TYPE -->
-        <!-- TODO: filtering by type unsupported by API (2 Sep. 24) -->
         <div class="mt-2 flex w-full flex-wrap md:w-1/2">
-          <span class="mr-2 w-full font-bold md:ml-2">TYPE:</span>
+          <label class="mr-2 w-full font-bold md:ml-2" for="type">TYPE:</label>
           <select
             id="type"
-            :value="filter.type"
-            name="type"
+            :value="filter.category"
+            name="category"
             class="flex w-full rounded-md ring-1 ring-gray-500 focus:ring-2 focus:ring-blood dark:bg-slate-700 dark:text-white md:ml-2"
-            @input="updateFilter('type', $event.target.value)"
+            @input="updateFilter('category', $event.target.value)"
           >
             <option :key="''" :value="''" text="Any" />
             <option
-              v-for="rtg in MAGIC_ITEMS_TYPES"
-              :key="rtg"
-              class=""
-              v-text="rtg"
+              v-for="category in MAGIC_ITEMS_TYPES"
+              :key="category"
+              :value="category.toLowerCase().split(' ').join('-')"
+              v-text="category"
             />
           </select>
         </div>
 
         <!-- FILTER BY ATTUNEMENT REQUIREMENT -->
         <div class="mt-4 flex w-full md:w-1/2">
-          <span class="mr-2 font-bold">REQUIRES ATTUNEMENT:</span>
+          <label class="mr-2 font-bold after:content-[':_']" for="attunement">
+            REQUIRES ATTUNEMENT
+          </label>
           <input
             id="attunement"
             :value="filter.requires_attunement"
@@ -79,12 +78,11 @@
       </div>
     </div>
   </div>
-  <!-- END FILTER BOX -->
 </template>
 
 <script setup>
 const props = defineProps({
-  filter: { type: Object, default: copyDefaultMonsterFilter() },
+  filter: { type: Object, default: copyMagicItemFilter() },
   updateFilter: { type: Function, required: true },
 });
 </script>


### PR DESCRIPTION
This PR fixes the filters on the `/magic-items` page, which didn't survive the transition to API V2.

The filters were fixed by rectifying a couple of existant bugs in the filter and then changing field names so that they matched those return by the new version of the API.

Not all the filtering options that existed for magic items on V1 are currently implemented in V2 Open5e API `staging` branch, so this PR has a companion PR on the backend (https://github.com/open5e/open5e-api/pull/538) which need to be approved before all the features of this PR come online