### PR TITLE
API V2: Equpiment

### DIFF
--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -84,6 +84,10 @@ const endpoints = {
 const formatUrl = (input) => {
   let baseUrl = endpoints[input.object_model] ?? input.object_model;
 
+  // non-magic items link to /equipment route
+  if (baseUrl === 'magic-items' && !input?.object?.is_magic_item)
+    baseUrl = 'equipment';
+
   // subclass urls must be prepended by their base-class
   if (input?.object?.subclass_of) baseUrl += `/${input.object.subclass_of.key}`;
 
@@ -100,7 +104,10 @@ const formatCategory = (input) => {
   const category = input.object_model.match(/[A-Z][a-z]+/g).join(' ');
   // Creatures -> Monsters
   if (category === 'Creature') return 'Monster';
+  // Items (Magic) -> 'Magic Item'
   if (input.object?.is_magic_item) return 'Magic Item';
+  // Items (Rest) -> 'Equipment'
+  if (category === 'Item') return 'Equipment';
   // Character Class -> Class OR [CLASS] Subclass
   if (category === 'Character Class') {
     if (input?.object?.subclass_of)
@@ -111,6 +118,8 @@ const formatCategory = (input) => {
   if (input?.object?.subrace_of)
     return `${input.object.subrace_of.name} Subrace`;
   return category; // BASE-CASE: return category without alteration
+
+  // Non-magic items -> Equipment
 };
 </script>
 

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -13,6 +13,7 @@ export const API_ENDPOINTS = {
   search: 'v2/search/',
   spells: 'v2/spells/',
   rules: 'v2/rulesets/',
+  equipment: 'v2/items/',
 } as const;
 
 /** Provides the base functions to easily fetch data from the Open5e API. */

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -178,7 +178,6 @@ const routes = computed(() => [
     title: 'Spells',
     route: '/spells',
   },
-
   {
     title: 'Backgrounds',
     route: '/backgrounds',
@@ -186,6 +185,10 @@ const routes = computed(() => [
   {
     title: 'Feats',
     route: '/feats',
+  },
+  {
+    title: 'Equipment',
+    route: '/equipment',
   },
   {
     title: 'Conditions',

--- a/pages/equipment/[id].vue
+++ b/pages/equipment/[id].vue
@@ -3,15 +3,19 @@
     <div v-if="item">
       <h1 class="inline">{{ item.name }}</h1>
 
-      <p class="flex gap-2">
-        <span>{{ item.category.name }}</span>
-        <span v-if="parseFloat(item.weight) > 0" class="before:content-['_|_']">
-          {{ formatWeight(item.weight) }}
-        </span>
-        <span v-if="parseFloat(item.cost) > 0" class="before:content-['_|_']">
-          {{ formatCost(item.cost) }}
-        </span>
-      </p>
+      <!-- DISPLAY COMMON ITEM DATA: category, cost, weight, &c -->
+      <dl class="flex gap-2">
+        <dt class="font-bold">Category</dt>
+        <dd>{{ item.category.name }}</dd>
+        <template v-if="parseFloat(item.weight) > 0">
+          <dt class="font-bold before:content-['_|_']">Weight</dt>
+          <dd>{{ formatWeight(item.weight) }}</dd>
+        </template>
+        <template v-if="parseFloat(item.cost) > 0">
+          <dt class="font-bold before:content-['_|_']">Cost</dt>
+          <dd>{{ formatCost(item.cost) }}</dd>
+        </template>
+      </dl>
 
       <p class="text-sm italic">
         Source:

--- a/pages/equipment/[id].vue
+++ b/pages/equipment/[id].vue
@@ -6,7 +6,7 @@
       <!-- ITEM CARD FOR WEAPONS -->
       <div v-if="item.weapon">
         <p class="italic">{{ formatWeaponSubtitle(item.weapon) }}</p>
-        <dl class="grid grid-cols-2">
+        <dl class="grid grid-cols-[8rem_1fr]">
           <dt class="font-bold">Damage</dt>
           <dd>
             {{
@@ -34,15 +34,16 @@
             <dt class="font-bold">Range</dt>
             <dd>{{ `${item.weapon.range} / ${item.weapon.long_range}` }}</dd>
           </template>
-          <template v-if="item.weight">
+          <template v-if="parseFloat(item?.weight) > 0">
             <dt class="font-bold">Weight</dt>
-            <dd>{{ formatWeight(item.weight) }}</dd>
+            <dd>{{ `${parseFloat(item.weight)} lb` }}</dd>
           </template>
           <template v-if="item.cost">
             <dt class="font-bold">Cost</dt>
             <dd>{{ formatCost(item.cost) }}</dd>
           </template>
         </dl>
+        <md-viewer :text="item.desc" />
       </div>
 
       <!-- ITEM CARD FOR ARMOR -->
@@ -50,16 +51,16 @@
         <!-- TODO: whether armor is light/med/heavy not rtn'd by API -->
         <p>{{ `Armor (${'TODO'})` }}</p>
         <md-viewer :text="item.desc" />
-        <dl class="grid grid-cols-2">
+        <dl class="grid grid-cols-[6rem_1fr]">
           <dt class="font-bold">AC</dt>
           <dd>{{ item.armor.ac_display }}</dd>
           <template v-if="item.armor.grants_stealth_disadvantage">
             <dt class="font-bold">Stealth</dt>
             <dd>Disadvantage</dd>
           </template>
-          <template v-if="item.weight">
+          <template v-if="parseFloat(item?.weight) > 0">
             <dt class="font-bold">Weight</dt>
-            <dd>{{ formatWeight(item.weight) }}</dd>
+            <dd>{{ `${parseFloat(item.weight)} lb` }}</dd>
           </template>
           <template v-if="item.cost">
             <dt class="font-bold">Cost</dt>
@@ -70,15 +71,15 @@
 
       <!-- DISPLAY COMMON ITEM DATA: category, cost, weight, &c -->
       <div v-else>
-        <dl class="flex gap-2">
+        <dl class="grid grid-cols-[6rem_1fr]">
           <dt class="font-bold">Category</dt>
           <dd>{{ item.category.name }}</dd>
-          <template v-if="parseFloat(item.weight) > 0">
-            <dt class="font-bold before:content-['_|_']">Weight</dt>
-            <dd>{{ formatWeight(item.weight) }}</dd>
+          <template v-if="parseFloat(item?.weight) > 0">
+            <dt class="font-bold">Weight</dt>
+            <dd>{{ `${parseFloat(item.weight)} lb` }}</dd>
           </template>
           <template v-if="parseFloat(item.cost) > 0">
-            <dt class="font-bold before:content-['_|_']">Cost</dt>
+            <dt class="font-bold">Cost</dt>
             <dd>{{ formatCost(item.cost) }}</dd>
           </template>
         </dl>
@@ -92,6 +93,7 @@
         </a>
       </p>
     </div>
+
     <p v-else>Loading...</p>
   </section>
 </template>
@@ -111,12 +113,6 @@ const formatCost = (input) => {
     (parseInt(silver) > 0 ? `${silver} sp` : '') +
     (parseInt(copper) > 0 ? `${copper} cp` : '')
   );
-};
-
-const formatWeight = (input) => {
-  const weight = parseFloat(input);
-  if (weight >= 1) return `${weight} lb`;
-  return `1 lb for ${1 / weight}`;
 };
 
 const formatWeaponSubtitle = (weapon) =>

--- a/pages/equipment/[id].vue
+++ b/pages/equipment/[id].vue
@@ -6,7 +6,7 @@
       <!-- ITEM CARD FOR WEAPONS -->
       <div v-if="item.weapon">
         <p class="italic">{{ formatWeaponSubtitle(item.weapon) }}</p>
-        <dl class="grid auto-cols-max grid-cols-2">
+        <dl class="grid grid-cols-2">
           <dt class="font-bold">Damage</dt>
           <dd>
             {{
@@ -20,10 +20,12 @@
           <dd class="capitalize">
             {{ item.weapon.damage_type.split('/').slice(-2)[0] }}
           </dd>
-          <dt class="font-bold">Properties</dt>
-          <dd class="capitalize">
-            {{ item.weapon.properties.map((prop) => prop).join(', ') }}
-          </dd>
+          <template v-if="item.weapon.properties.length > 0">
+            <dt class="font-bold">Properties</dt>
+            <dd class="capitalize">
+              {{ item.weapon.properties.map((prop) => prop).join(', ') }}
+            </dd>
+          </template>
           <template v-if="item.weapon.is_reach">
             <dt class="font-bold">Reach</dt>
             <dd>{{ item.weapon.reach + ' ft.' }}</dd>
@@ -31,6 +33,29 @@
           <template v-if="item.weapon.range">
             <dt class="font-bold">Range</dt>
             <dd>{{ `${item.weapon.range} / ${item.weapon.long_range}` }}</dd>
+          </template>
+          <template v-if="item.weight">
+            <dt class="font-bold">Weight</dt>
+            <dd>{{ formatWeight(item.weight) }}</dd>
+          </template>
+          <template v-if="item.cost">
+            <dt class="font-bold">Cost</dt>
+            <dd>{{ formatCost(item.cost) }}</dd>
+          </template>
+        </dl>
+      </div>
+
+      <!-- ITEM CARD FOR ARMOR -->
+      <div v-else-if="item.armor">
+        <!-- TODO: whether armor is light/med/heavy not rtn'd by API -->
+        <p>{{ `Armor (${'TODO'})` }}</p>
+        <md-viewer :text="item.desc" />
+        <dl class="grid grid-cols-2">
+          <dt class="font-bold">AC</dt>
+          <dd>{{ item.armor.ac_display }}</dd>
+          <template v-if="item.armor.grants_stealth_disadvantage">
+            <dt class="font-bold">Stealth</dt>
+            <dd>Disadvantage</dd>
           </template>
           <template v-if="item.weight">
             <dt class="font-bold">Weight</dt>

--- a/pages/equipment/[id].vue
+++ b/pages/equipment/[id].vue
@@ -1,0 +1,51 @@
+<template>
+  <section class="docs-container container">
+    <div v-if="item">
+      <h1 class="inline">{{ item.name }}</h1>
+
+      <p class="flex gap-2">
+        <span>{{ item.category.name }}</span>
+        <span v-if="parseFloat(item.weight) > 0" class="before:content-['_|_']">
+          {{ formatWeight(item.weight) }}
+        </span>
+        <span v-if="parseFloat(item.cost) > 0" class="before:content-['_|_']">
+          {{ formatCost(item.cost) }}
+        </span>
+      </p>
+
+      <p class="text-sm italic">
+        Source:
+        <a target="NONE" :href="item.document.permalink">
+          {{ item.document.name }}
+          <Icon name="heroicons:arrow-top-right-on-square-20-solid" />
+        </a>
+      </p>
+    </div>
+    <p v-else>Loading...</p>
+  </section>
+</template>
+
+<script setup>
+const { data: item } = useFindOne(
+  API_ENDPOINTS.equipment,
+  useRoute().params.id,
+  { is_magic_item: false, depth: 1 }
+);
+
+const formatCost = (input) => {
+  const [gold, rest] = input.split('.');
+  const [silver, copper] = rest.split('');
+  console.log(gold, silver, copper);
+  return (
+    (parseInt(gold) > 0 ? `${gold} gp` : '') +
+    (parseInt(silver) > 0 ? `${silver} sp` : '') +
+    (parseInt(copper) > 0 ? `${copper} cp` : '')
+  );
+};
+
+const formatWeight = (input) => {
+  const weight = parseFloat(input);
+  if (weight >= 1) return `${weight} lb`;
+  return `1 lb for ${1 / weight}`;
+};
+</script>

--- a/pages/equipment/[id].vue
+++ b/pages/equipment/[id].vue
@@ -1,22 +1,64 @@
 <template>
   <section class="docs-container container">
     <div v-if="item">
-      <h1 class="inline">{{ item.name }}</h1>
+      <h1>{{ item.name }}</h1>
+
+      <!-- ITEM CARD FOR WEAPONS -->
+      <div v-if="item.weapon">
+        <p class="italic">{{ formatWeaponSubtitle(item.weapon) }}</p>
+        <dl class="grid auto-cols-max grid-cols-2">
+          <dt class="font-bold">Damage</dt>
+          <dd>
+            {{
+              item.weapon.damage_dice +
+              (item.weapon.is_versatile
+                ? ` (${item.weapon.versatile_dice})`
+                : '')
+            }}
+          </dd>
+          <dt class="font-bold">Damage Type</dt>
+          <dd class="capitalize">
+            {{ item.weapon.damage_type.split('/').slice(-2)[0] }}
+          </dd>
+          <dt class="font-bold">Properties</dt>
+          <dd class="capitalize">
+            {{ item.weapon.properties.map((prop) => prop).join(', ') }}
+          </dd>
+          <template v-if="item.weapon.is_reach">
+            <dt class="font-bold">Reach</dt>
+            <dd>{{ item.weapon.reach + ' ft.' }}</dd>
+          </template>
+          <template v-if="item.weapon.range">
+            <dt class="font-bold">Range</dt>
+            <dd>{{ `${item.weapon.range} / ${item.weapon.long_range}` }}</dd>
+          </template>
+          <template v-if="item.weight">
+            <dt class="font-bold">Weight</dt>
+            <dd>{{ formatWeight(item.weight) }}</dd>
+          </template>
+          <template v-if="item.cost">
+            <dt class="font-bold">Cost</dt>
+            <dd>{{ formatCost(item.cost) }}</dd>
+          </template>
+        </dl>
+      </div>
 
       <!-- DISPLAY COMMON ITEM DATA: category, cost, weight, &c -->
-      <dl class="flex gap-2">
-        <dt class="font-bold">Category</dt>
-        <dd>{{ item.category.name }}</dd>
-        <template v-if="parseFloat(item.weight) > 0">
-          <dt class="font-bold before:content-['_|_']">Weight</dt>
-          <dd>{{ formatWeight(item.weight) }}</dd>
-        </template>
-        <template v-if="parseFloat(item.cost) > 0">
-          <dt class="font-bold before:content-['_|_']">Cost</dt>
-          <dd>{{ formatCost(item.cost) }}</dd>
-        </template>
-      </dl>
-
+      <div v-else>
+        <dl class="flex gap-2">
+          <dt class="font-bold">Category</dt>
+          <dd>{{ item.category.name }}</dd>
+          <template v-if="parseFloat(item.weight) > 0">
+            <dt class="font-bold before:content-['_|_']">Weight</dt>
+            <dd>{{ formatWeight(item.weight) }}</dd>
+          </template>
+          <template v-if="parseFloat(item.cost) > 0">
+            <dt class="font-bold before:content-['_|_']">Cost</dt>
+            <dd>{{ formatCost(item.cost) }}</dd>
+          </template>
+        </dl>
+        <md-viewer :text="item.desc" />
+      </div>
       <p class="text-sm italic">
         Source:
         <a target="NONE" :href="item.document.permalink">
@@ -39,7 +81,6 @@ const { data: item } = useFindOne(
 const formatCost = (input) => {
   const [gold, rest] = input.split('.');
   const [silver, copper] = rest.split('');
-  console.log(gold, silver, copper);
   return (
     (parseInt(gold) > 0 ? `${gold} gp` : '') +
     (parseInt(silver) > 0 ? `${silver} sp` : '') +
@@ -52,4 +93,9 @@ const formatWeight = (input) => {
   if (weight >= 1) return `${weight} lb`;
   return `1 lb for ${1 / weight}`;
 };
+
+const formatWeaponSubtitle = (weapon) =>
+  `${weapon.is_melee ? 'Melee' : 'Ranged'} weapon ` +
+  `(${weapon.is_martial ? 'martial' : 'simple'}, ` +
+  `${weapon.name.toLowerCase()})`;
 </script>

--- a/pages/equipment/index.vue
+++ b/pages/equipment/index.vue
@@ -1,0 +1,89 @@
+<template>
+  <section>
+    <div class="flex">
+      <h1 class="my-2 w-full">Equipment</h1>
+      <api-table-nav
+        :page-number="pageNo"
+        :last-page-number="lastPageNo"
+        @first="firstPage()"
+        @next="nextPage()"
+        @prev="prevPage()"
+        @last="lastPage()"
+      />
+    </div>
+
+    <api-table-filter
+      :update-filters="update"
+      :search="{
+        name: 'Search Equipment',
+        filterField: 'name__icontains',
+      }"
+      :select-fields="[
+        {
+          name: 'Category',
+          filterField: 'category',
+          options: [
+            'Adventuring Gear',
+            'Ammunition',
+            'Armor',
+            'Drawn Vehicle',
+            'Poison',
+            'Ring',
+            'Rod',
+            'Shield',
+            'Staff',
+            'Tools',
+            'Trade Goods',
+            'Wand',
+            'Waterborne Vehicle',
+            'Weapon',
+          ].map((category) => ({
+            name: category,
+            value: category.toLowerCase().split(' ').join('-'),
+          })),
+        },
+      ]"
+    />
+
+    <api-results-table
+      v-model="debouncedFilter"
+      :data="data?.results"
+      :cols="[
+        {
+          displayName: 'Name',
+          value: (data) => data.name,
+          sortValue: 'name',
+          link: (data) => `/equipment/${data.key}`,
+        },
+        {
+          displayName: 'Category',
+          value: (data) => data.category.name,
+          sortValue: 'category',
+        },
+      ]"
+      :sort-by="sortBy"
+      :is-sort-descending="isSortDescending"
+      @sort="(sortValue) => setSortState(sortValue)"
+    />
+  </section>
+</template>
+
+<script setup>
+// State handlers for sorting results table
+const { sortBy, isSortDescending, setSortState } = useSortState();
+
+// Set up filters
+const { debouncedFilter, update } = useFilterState();
+
+const fields = ['key', 'name', 'document', 'category'].join(',');
+const { data, paginator } = useFindPaginated({
+  endpoint: API_ENDPOINTS.equipment,
+  sortByProperty: sortBy,
+  isSortDescending: isSortDescending,
+  filter: debouncedFilter,
+  params: { fields, is_magic_item: false, depth: 1 },
+});
+
+const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
+  paginator;
+</script>


### PR DESCRIPTION
This PR closes #596 by adding the following pages to the Open5e website:

- `/equipment` - a top-level page for displaying all non-magical equipment
- `/equipment/[id]` - page for viewing details of specific kinds of non-magical equipment

Additional changes were made to the layout (adding a link to `/equipment` in the navbar) and the `<search-result>` component (so it correctly generated links to the new `/equipment/[id]` pages)

A couple bugs in the API were surfaced during the development for this feature:
- Some magical weapons were labelled as non-magical in the V2 dataset - https://github.com/open5e/open5e-api/issues/574
- V2 armor data model doesn't include armor type/proficiency class (not sure the exact terminology) - whether a piece of armor is light, medium or heavy