### PR TITLE
API V2: Redirects

### DIFF
--- a/composables/api.ts
+++ b/composables/api.ts
@@ -84,10 +84,12 @@ export const useAPI = () => {
     },
     get: async (...parts: string[]) => {
       const route = parts.join('');
-      const res = await api.get(route, {
-        params: { depth: '2' },
+      const res = await api.get(route, { params: { depth: '2' } }).catch(() => {
+        // redirect to /search if API route returns nothing
+        const searchTerm = parts.filter((exists) => exists).slice(-1)[0];
+        navigateTo(`/search?text=${searchTerm}`);
       });
-      return res.data as Record<string, any>;
+      return res?.data as Record<string, any>;
     },
   };
 };

--- a/middleware/redirects.global.js
+++ b/middleware/redirects.global.js
@@ -1,64 +1,47 @@
-// add redirects for exact path matches here
-const redirects = {
+// if a url matches a key, trigger redirect to value
+const exactMatchesToRedirect = {
   '/monsters/monster-list': '/monsters',
   '/magicitems/magicitem-list': '/magic-items',
   '/spells/spells-table': '/spells',
   '/magicitems': '/magic-items',
+  '/sections': '/rules',
 };
 
-// add redirects for partial path matches here
-const substitutions = [
-  {
-    find: '/magicitems',
-    replaceWith: '/magic-items',
-  },
+// if a url contains 'find' as a substring, trigger redirect to 'to'
+const partialMatchesToRedirect = [
+  { find: '/combat', to: '/rules' },
+  { find: '/characters', to: '/rules' },
+  { find: '/gameplay-mechanics', to: '/rules' },
+  { find: '/running', to: '/rules' },
 ];
 
-// redirects from /sections routes require extra data from API
-async function replaceSectionsWithParent(path) {
-  const slug = path.split('/')[2]; // isolate UID
-  const apiURL = useRuntimeConfig().public.apiUrl;
-  const endpoint = `${apiURL}/sections/${slug}`;
-
-  // fetch section parent & create redirect URL
-  const { data } = await useFetch(endpoint);
-  if (!data?.value) {
-    return;
-  }
-
-  // slugify section parent
-  const parent = data.value.parent
-    .toLowerCase()
-    .replace(/\s+/g, '-') // replace spaces with hyphens
-    .replace('rules', 'gameplay-mechanics'); // handle common inconsistancy in data-set
-  return `/${parent}/${slug}`;
-}
+// if a url contains a substring, replace it with another substring
+const substitutions = [{ find: '/magicitems', replaceWith: '/magic-items' }];
 
 export default defineNuxtRouteMiddleware((to) => {
-  // redirecting only works client-side, return if server-side
-  if (process.server) {
-    return;
-  }
-
   // remove terminal slash from path
   const path = to.fullPath.endsWith('/')
     ? to.fullPath.slice(0, -1)
     : to.fullPath;
 
-  // if entire path is present in redirects obj, navigate to it
-  if (redirects[path]) {
-    return navigateTo(redirects[path], { redirectCode: 301 });
+  // handle exact url match redirects
+  if (exactMatchesToRedirect[path]) {
+    return navigateTo(exactMatchesToRedirect[path], { redirectCode: 301 });
   }
 
-  // check whether any part of the path needs to be replaced
+  // handle partial url match redirects
+  const partialMatchRedirect = partialMatchesToRedirect
+    .map(({ find, to }) => {
+      if (path.search(find) > -1) return to;
+    })
+    .filter((exists) => !!exists);
+  if (partialMatchRedirect.length > 0)
+    return navigateTo(partialMatchRedirect[0], { redirectCode: 301 });
+
+  // finally, check if any substring substitutions need to be made
   substitutions.forEach(({ find, replaceWith }) => {
     if (path.search(find) > -1) {
       return navigateTo(path.replace(find, replaceWith), { redirectCode: 301 });
     }
   });
-
-  // check whether a /section/ route needs to be replaced with parent from API
-  if (path.search('/sections/') > -1) {
-    return navigateTo(replaceSectionsWithParent(path), { redirectCode: 301 });
-  }
 });


### PR DESCRIPTION
This PR closes #545 by updating the redirecting logic to work gracefully with items whose URLs have been changed between API V1 and V2.

- Updates to `middleware/redirects.global.js` make redirects work with the new site structure. Specifically, this handles redirects from all the former pages spun up from the V1 `/sections` endpoint (which has been replaced by `/rules` and `/rulesets` in V2).
- Updates to `composables/api.ts` which now redirect to the `/search` route when a specific key is not found in the Open5e dataset (with query string pre-populated with the missing key). This is a simple way to handle the many instances where item keys have changed