### PR TITLE
Bugfix: `/spell` page not requesting correct fields from API

### DIFF
--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -107,7 +107,7 @@
 const { sortBy, isSortDescending, setSortState } = useSortState();
 
 // fields to fetch from API to populate table
-const fields = ['name', 'document', 'level', 'school', 'classes'];
+const fields = ['name', 'document', 'level', 'school', 'classes'].join(',');
 
 const { debouncedFilter, update } = useFilterState();
 


### PR DESCRIPTION
A quick one-liner to correctly compose the `fields` property as a comma-seperated list before passing it to the API. Previous, the API was return all fields for all spells on the top-level page because the query param was malformed.