### PR TITLE
Bugfix (API V2) - fixed query params on `/backgrounds` route

### DIFF
--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -39,7 +39,7 @@ const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.backgrounds,
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
-  params: { fields: ['name', 'key', 'document'], depth: 1 },
+  params: { fields: ['name', 'key', 'document'].join(','), depth: 1 },
 });
 
 // destructure pagination controls


### PR DESCRIPTION
This problem fixes a similar problem to #599, only this time on the `/backgrounds` route.

The bug was in the value passed to the `fields` parameter to the `usePaginated` composable. This parameter control which fields should be return by the server in the API response. It expects a comma-seperated string, but was instead passed an array of fields with the `.join(',')` method omitted.

This resulted in a query param of the form `?fields[]=name&fields[]=key&fields[]=document` when the form `?fields=name,key,document` is required by the API to filter it correctly