### PR TITLE
Update fetching of nested parameters

### DIFF
--- a/components/ApiResultRow.vue
+++ b/components/ApiResultRow.vue
@@ -7,7 +7,7 @@
           <nuxt-link :to="col.link(data)">
             {{ col.value(data) }}
           </nuxt-link>
-          <source-tag :text="slug" :title="data.document.name" />
+          <source-tag :text="data.document.key" :title="data.document.name" />
         </span>
       </template>
       <!-- If data is boolean, display as √ or -, not true or false  -->
@@ -26,13 +26,4 @@ const props = defineProps({
   data: { type: Object, default: () => {} }, // Open5e data to render
   cols: { type: Array, default: () => [] }, // Arr. of table columns to render
 });
-
-// Workaround for API V2 no returning Document 'key'
-// Extrapolate key from 'url'
-const slug = computed(() =>
-  props.data.document.url
-    .split('/')
-    .filter((exists) => exists)
-    .pop()
-);
 </script>

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -158,6 +158,8 @@ const closeModal = () => emit('close');
 
 const { data: documents } = useDocuments({
   fields: ['key', 'name', 'publisher', 'gamesystem'].join(','),
+  publisher__fields: ['name', 'key'].join(','),
+  gamesystem__fields: ['name', 'key'].join(','),
 });
 
 // filter documents by the current game system

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -267,7 +267,7 @@ export const useDocuments = (params: Record<string, any> = {}) => {
   params.depth = '1';
   const { findMany } = useAPI();
   return useQuery({
-    queryKey: ['findMany', API_ENDPOINTS.documents],
+    queryKey: ['findMany', API_ENDPOINTS.documents, params],
     queryFn: () => findMany(API_ENDPOINTS.documents, [], params),
   });
 };

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -146,7 +146,12 @@ const showModal = ref(false);
 const { sources } = useSourcesList();
 
 const no_selected_sources = computed(() => sources.value.length);
-const { data: documents } = useDocuments();
+
+const { data: documents } = useDocuments({
+  fields: 'none', // we only need to document count, so we can omit all fields
+  depth: 0,
+});
+
 const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
   fields: ['name', 'key'].join(),
   is_subclass: false,

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -39,7 +39,11 @@ const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.backgrounds,
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
-  params: { fields: ['name', 'key', 'document'].join(','), depth: 1 },
+  params: {
+    fields: ['name', 'key', 'document'].join(','),
+    document__fields: ['name', 'key'].join(','),
+    depth: 1,
+  },
 });
 
 // destructure pagination controls

--- a/pages/classes/index.vue
+++ b/pages/classes/index.vue
@@ -51,6 +51,7 @@ const { data, paginator } = useFindPaginated({
   params: {
     is_subclass: false,
     fields: ['key', 'name', 'document'].join(),
+    document__fields: ['name', 'key'].join(),
     depth: 1,
   },
 });

--- a/pages/conditions/index.vue
+++ b/pages/conditions/index.vue
@@ -30,7 +30,11 @@
 // fetch page of data from API and pagination controls
 const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.conditions,
-  params: { fields: ['name', 'key', 'document'].join(','), depth: 1 },
+  params: {
+    fields: ['name', 'key', 'document'].join(','),
+    documents__fields: ['name', 'key'].join(','),
+    depth: 1,
+  },
 });
 
 // destructure pagination controls

--- a/pages/equipment/index.vue
+++ b/pages/equipment/index.vue
@@ -76,12 +76,21 @@ const { sortBy, isSortDescending, setSortState } = useSortState();
 const { debouncedFilter, update } = useFilterState();
 
 const fields = ['key', 'name', 'document', 'category'].join(',');
+const docFields = ['name', 'key'].join(',');
+const categoryFields = ['name'].join(',');
+
 const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.equipment,
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
   filter: debouncedFilter,
-  params: { fields, is_magic_item: false, depth: 1 },
+  params: {
+    fields,
+    document__fields: docFields,
+    category__fields: categoryFields,
+    is_magic_item: false,
+    depth: 1,
+  },
 });
 
 const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =

--- a/pages/feats/index.vue
+++ b/pages/feats/index.vue
@@ -38,7 +38,11 @@ const { data, paginator } = useFindPaginated({
   endpoint: API_ENDPOINTS.feats,
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
-  params: { fields: ['key', 'name', 'document'].join(','), depth: 1 },
+  params: {
+    fields: ['key', 'name', 'document'].join(','),
+    document__fields: ['name', 'key'].join(','),
+    depth: 1,
+  },
 });
 
 const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =

--- a/pages/magic-items/index.vue
+++ b/pages/magic-items/index.vue
@@ -100,7 +100,13 @@ const { data, paginator } = useFindPaginated({
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
   filter: debouncedFilter,
-  params: { fields, is_magic_item: true, depth: 1 },
+  params: {
+    is_magic_item: true,
+    fields,
+    document__fields: ['name', 'key'].join(','),
+    category__fields: ['name', 'key'].join(','),
+    rarity__fields: ['name', 'rank'].join(','),
+  },
 });
 
 // destructure pagination controls

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -121,7 +121,14 @@ const { data, paginator } = useFindPaginated({
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
   filter: filter,
-  params: { fields, is_subclass: false, depth: 1 },
+  params: {
+    fields,
+    document__fields: 'name,key',
+    type__fields: 'name',
+    size__fields: 'name,key',
+    is_subclass: false,
+    depth: 1,
+  },
 });
 
 // destructure pagination controls

--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -39,6 +39,7 @@ const { data, paginator } = useFindPaginated({
   isSortDescending: isSortDescending,
   params: {
     fields: ['name', 'key', 'document'].join(','),
+    document__fields: ['name', 'key'].join(','),
     subrace_of__isnull: true,
     depth: 1,
   },

--- a/pages/rules/index.vue
+++ b/pages/rules/index.vue
@@ -50,6 +50,7 @@ const { data, paginator } = useFindPaginated({
   filter: debouncedFilter,
   params: {
     fields: ['name', 'key', 'document'].join(','),
+    document__fields: ['name', 'key'].join(','),
     depth: 1,
   },
 });

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -107,7 +107,9 @@
 const { sortBy, isSortDescending, setSortState } = useSortState();
 
 // fields to fetch from API to populate table
-const fields = ['name', 'document', 'level', 'school', 'classes'].join(',');
+const fields = ['key', 'name', 'document', 'level', 'school', 'classes'].join(
+  ','
+);
 
 const { debouncedFilter, update } = useFilterState();
 
@@ -117,7 +119,13 @@ const { data, paginator } = useFindPaginated({
   sortByProperty: sortBy,
   isSortDescending: isSortDescending,
   filter: debouncedFilter,
-  params: { fields, depth: 1 },
+  params: {
+    fields,
+    document__fields: ['name', 'key'].join(','),
+    classes__fields: ['name'].join(','),
+    school__fields: ['name', 'key'].join(','),
+    depth: 1,
+  },
 });
 
 // destructure pagination controls


### PR DESCRIPTION
This PR leverages new features on V2 of the Open5e API to resolve issues related to the over-fetching of data on top-level pages. Previously, you could declare which fields to include in an API response via the `?fields=` query parameter, but there was no way to filter nested fields (one very common use-case is only needing the`name` and `key` child fields of the `document` field).

As of [PR #601 on the backend](https://github.com/open5e/open5e-api/pull/601), it is now to control these using the `?parentfields_fields` query parameter.

