### PR TITLE
API V2: Update query params for `/monsters/[id]` route

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -103,7 +103,8 @@ table {
   h3,
   h4,
   h5,
-  h6 {
+  h6,
+  section {
     max-width: 40rem;
   }
   th:first-child {

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -38,19 +38,7 @@
         {{ monster.alignment }}
       </span>
 
-      <!-- 
-        Source-tag text param is ugly, but might require work on the API first.
-        Workaround for key not being returned from API. Get it from URL instead
-      -->
-      <source-tag
-        :title="monster.document.name"
-        :text="
-          monster.document.url
-            .split('/')
-            .filter((slug) => slug)
-            .slice(-1)[0]
-        "
-      />
+      <source-tag :title="monster.document.name" :text="monster.document.key" />
     </p>
 
     <ul>
@@ -363,7 +351,7 @@
         :key="environemnt.id"
         class="text-sm after:content-['.'] [&:not(:last-child)]:after:content-[',_']"
       >
-        {{ environemnt }}
+        {{ environemnt.name }}
       </span>
     </section>
 
@@ -390,9 +378,15 @@
 
 <script setup>
 const route = useRoute();
+const params = {
+  environments__fields: 'name',
+  languages__fields: 'name',
+  document__fields: 'name,key,permalink',
+};
 const { data: monster } = useFindOne(
   API_ENDPOINTS.monsters,
-  useRoute().params.id
+  useRoute().params.id,
+  { params }
 );
 
 // filter "unit" prop from "speeds"


### PR DESCRIPTION
This PR leverages recent changes to the V2 API (https://github.com/open5e/open5e-api/pull/603) to further streamline queries made from the `/monsters/[id]` route.

Specifically this PR reduces the amount of data fetched by the nested `document`, `environments` and `languages` to only those fields which were required.

For monsters with a large numbers of languages and environments a substantial reduction in the size of the JSON response was achieved. ie. the Abominable Beauty from Tome of Heroes returned a ~50% smaller payload after these changes while displaying the same information on the page.

The small change to the SCSS was made to fix a visual bug on the Environments section, where it would overflow the width of the container