### PR TITLE
Feature: `<NavBar>` component

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -1,0 +1,78 @@
+<template>
+  <ul class="text-inherit text-white">
+    <li v-for="section in routes" :key="section.title">
+      <nav-link :to="section.route">
+        {{ section.title }}
+      </nav-link>
+      <ul
+        v-if="section.subroutes"
+        v-show="path.indexOf(section.route) != -1"
+        class="bg-slate-800/30 py-2"
+      >
+        <li v-for="page in section.subroutes" :key="page.key">
+          <nav-link :to="`${section.route}/${page.key}`" :indent="true">
+            {{ page.name }}
+          </nav-link>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</template>
+
+<script setup>
+import { useRoute } from 'nuxt/app';
+const { path } = useRoute();
+
+const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
+  fields: ['name', 'key'].join(),
+  is_subclass: false,
+});
+
+const routes = computed(() => [
+  {
+    title: 'Classes',
+    route: '/classes',
+    subroutes: classes.value ?? [],
+  },
+  {
+    title: 'Races',
+    route: '/races',
+  },
+  {
+    title: 'Monsters',
+    route: '/monsters',
+  },
+  {
+    title: 'Magic Items',
+    route: '/magic-items',
+  },
+  {
+    title: 'Spells',
+    route: '/spells',
+  },
+  {
+    title: 'Backgrounds',
+    route: '/backgrounds',
+  },
+  {
+    title: 'Feats',
+    route: '/feats',
+  },
+  {
+    title: 'Equipment',
+    route: '/equipment',
+  },
+  {
+    title: 'Conditions',
+    route: '/conditions',
+  },
+  {
+    title: 'Rules',
+    route: '/rules',
+  },
+  {
+    title: 'API Docs',
+    route: '/api-docs',
+  },
+]);
+</script>

--- a/composables/api.ts
+++ b/composables/api.ts
@@ -96,7 +96,7 @@ export const useAPI = () => {
 
 export const useFindMany = (
   endpoint: MaybeRef<string>,
-  params?: MaybeRef<Record<string, string | number>>
+  params?: MaybeRef<Record<string, string | number | boolean>>
 ) => {
   const { findMany } = useAPI();
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -59,25 +59,8 @@
           />
         </div>
 
-        <!-- Navigation Links -->
-        <ul class="text-inherit text-white">
-          <li v-for="section in routes" :key="section.title">
-            <nav-link :to="section.route">
-              {{ section.title }}
-            </nav-link>
-            <ul
-              v-if="section.subroutes"
-              v-show="useRoute().path.indexOf(section.route) != -1"
-              class="bg-slate-800/30 py-2"
-            >
-              <li v-for="page in section.subroutes" :key="page.key">
-                <nav-link :to="`${section.route}/${page.key}`" :indent="true">
-                  {{ page.name }}
-                </nav-link>
-              </li>
-            </ul>
-          </li>
-        </ul>
+        <!-- Sidebar Navigation -->
+        <NavBar />
 
         <!-- Report Issue UI -->
         <report-issue />
@@ -154,62 +137,9 @@ const { data: documents } = useDocuments({
   depth: 0,
 });
 
-const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
-  fields: ['name', 'key'].join(),
-  is_subclass: false,
-});
-
 const no_available_sources = computed(() => documents.value?.length ?? 0);
 
 const isLoadingData = useIsFetching();
-
-const routes = computed(() => [
-  {
-    title: 'Classes',
-    route: '/classes',
-    subroutes: classes.value ?? [],
-  },
-  {
-    title: 'Races',
-    route: '/races',
-  },
-  {
-    title: 'Monsters',
-    route: '/monsters',
-  },
-  {
-    title: 'Magic Items',
-    route: '/magic-items',
-  },
-  {
-    title: 'Spells',
-    route: '/spells',
-  },
-  {
-    title: 'Backgrounds',
-    route: '/backgrounds',
-  },
-  {
-    title: 'Feats',
-    route: '/feats',
-  },
-  {
-    title: 'Equipment',
-    route: '/equipment',
-  },
-  {
-    title: 'Conditions',
-    route: '/conditions',
-  },
-  {
-    title: 'Rules',
-    route: '/rules',
-  },
-  {
-    title: 'API Docs',
-    route: '/api-docs',
-  },
-]);
 
 const router = useRouter();
 
@@ -218,13 +148,8 @@ function doSearch(searchText) {
   showSidebar.value = false;
 }
 
-function toggleSidebar() {
-  showSidebar.value = !showSidebar.value;
-}
-
-function hideSidebar() {
-  showSidebar.value = false;
-}
+const toggleSidebar = () => (showSidebar.value = !showSidebar.value);
+const hideSidebar = () => (showSidebar.value = false);
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
This PR closes issue #634 by refactoring the navigation bar code from the `layouts/default.vue` file into the new `<NavBar>` component. This considerably streamlines the layout component, makingit more maintainable moving forward, and it also makes developing further features on the NavBar (ie. issue #507) simpler to develop.

Very little additional code was add this feature. It was mostly a straight cut and paste with a little tidying up. The change to the `composables/api.ts` was to fix a type error when passing a boolean prop to as a filter param to the `useFindMany()`.