### PR TITLE
Feature: Add Creature Traits to Monster Detail Page

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -240,7 +240,7 @@
     </section>
 
     <!-- TRAITS -->
-    <section v-if="monster.traits.length !== 0">
+    <section v-if="monster.traits?.length !== 0">
       <h2>Traits</h2>
       <ul id="traits-list">
         <li v-for="trait in monster.traits" :key="trait.key" class="my-1">

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -239,6 +239,19 @@
       </p>
     </section>
 
+    <!-- TRAITS -->
+    <section v-if="monster.traits.length !== 0">
+      <h2>Traits</h2>
+      <ul id="traits-list">
+        <li v-for="trait in monster.traits" :key="trait.key" class="my-1">
+          <span class="font-bold after:content-['._']">
+            {{ trait.name }}
+          </span>
+          <md-viewer :inline="true" :text="trait.desc" :use-roller="true" />
+        </li>
+      </ul>
+    </section>
+
     <!-- ACTIONS -->
     <section v-if="monster.actions.length !== 0">
       <h2>Actions</h2>

--- a/tests/unit/pages/monster.test.tsx
+++ b/tests/unit/pages/monster.test.tsx
@@ -203,6 +203,16 @@ mockNuxtImport('useFindOne', () => {
         },
       ],
       creaturesets: [],
+      traits: [
+        {
+          url: 'http://localhost:8000/v2/creaturetraits/srd_goblin_nimble-escape/',
+          key: 'srd_goblin_nimble-escape',
+          name: 'Nimble Escape',
+          desc: 'The goblin can take the Disengage or Hide action as a bonus action on each of its turns.',
+          type: null,
+          parent: 'http://localhost:8000/v2/creatures/srd_goblin/',
+        },
+      ],
     },
   });
 });


### PR DESCRIPTION
This PR closes issue https://github.com/open5e/open5e/issues/633 by adding the creature traits section on top of the actions section in the monster detail page. 

Screenshots: 
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/bb51d7b2-ae17-4ac5-90c4-28541fb53f2c" />

<img width="1454" alt="image" src="https://github.com/user-attachments/assets/a71c3dc5-cf70-45b7-854b-a8339a027342" />

