### PR TITLE
Task: Hide Size Column of Monsters Overview on Mobile

### DIFF
--- a/components/ApiResultRow.vue
+++ b/components/ApiResultRow.vue
@@ -1,7 +1,11 @@
 <template>
   <tr>
     <!-- Render each field defined in columns as a table cell -->
-    <td v-for="col in cols" :key="col.displayName">
+    <td
+      v-for="col in cols"
+      :key="col.displayName"
+      :class="{ 'hidden sm:block': col.isLeastPriority }"
+    >
       <template v-if="col.link">
         <span>
           <nuxt-link :to="col.link(data)">

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -8,6 +8,7 @@
             :key="col.field"
             :title="col.displayName"
             :sort-by="col.sortValue"
+            :is-least-priority="col.isLeastPriority"
             :is-sorting-property="sortBy === col.sortValue"
             :is-sort-descending="isSortDescending"
             @sort="onSort(col.sortValue)"

--- a/components/ApiTableFilter.vue
+++ b/components/ApiTableFilter.vue
@@ -27,6 +27,7 @@
       v-for="field in selectFields"
       :key="field.name"
       class="grid columns-1 justify-center"
+      :class="{ 'hidden sm:block': field.isLeastPriority }"
     >
       <label class="font-serif text-xs" :for="field.name">
         {{ field.name }}

--- a/components/SortableTableHeader.vue
+++ b/components/SortableTableHeader.vue
@@ -1,5 +1,9 @@
 <template>
-  <th :aria-sort="isSortDescending" class="align-baseline">
+  <th
+    :aria-sort="isSortDescending"
+    class="align-baseline"
+    :class="{ 'hidden sm:block': isLeastPriority }"
+  >
     <button v-if="sortBy" @click="onClick">
       <span>
         {{ format(title) }}
@@ -26,6 +30,7 @@ const props = defineProps({
   sortBy: { type: String, default: '' },
   isSortingProperty: { type: Boolean, default: false },
   isSortDescending: { type: Boolean, default: false },
+  isLeastPriority: { type: Boolean, default: false },
 });
 
 // a list of human-readable subsitutions

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -36,6 +36,7 @@
             name: monsterSize,
             value: monsterSize.toLowerCase(),
           })),
+          isLeastPriority: true,
         },
         {
           name: 'CR (min)',
@@ -82,6 +83,7 @@
           displayName: 'Size',
           value: (data) => data.size.name,
           sortValue: 'size',
+          isLeastPriority: true,
         },
       ]"
       :sort-by="sortBy"


### PR DESCRIPTION
This PR closes issue https://github.com/open5e/open5e/issues/636. 

- Hide the Size column of the Monsters table at narrow screen widths. [Done]
- Hide the Size filtering UI at the top of the Monsters tables at narrow screen widths. [Done] 
- Bonus points if you can find a way to unset the Size filtering state on the Monsters table when the Size column is omitted. [x]

**Change Log:**
Adding a new flag `isLeastPriority` in the share components, if is true, it will be hidden on small screen. 

<img width="1471" alt="image" src="https://github.com/user-attachments/assets/bcf0f2f2-1ee0-49fd-b222-8cd860568039" />

<img width="591" alt="image" src="https://github.com/user-attachments/assets/107d5d73-5470-4eb4-9615-078b05c1a420" />
