### PR TITLE
feat: Add useBreakpoints composable for responsive design support

### DIFF
--- a/composables/useBreakpoints.ts
+++ b/composables/useBreakpoints.ts
@@ -9,13 +9,14 @@ const breakpoints = {
 };
 
 export function useBreakpoints() {
-  const width = ref(window.innerWidth);
+  const width = ref<number | null>(null);
 
   const updateWidth = () => {
     width.value = window.innerWidth;
   };
 
   onMounted(() => {
+    updateWidth();
     window.addEventListener('resize', updateWidth);
   });
 
@@ -24,6 +25,7 @@ export function useBreakpoints() {
   });
 
   const currentSize = computed(() => {
+    if (width.value === null) return 'unknown';
     if (width.value >= breakpoints.xxl) return 'xxl';
     if (width.value >= breakpoints.xl) return 'xl';
     if (width.value >= breakpoints.lg) return 'lg';

--- a/composables/useBreakpoints.ts
+++ b/composables/useBreakpoints.ts
@@ -1,0 +1,43 @@
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+
+const breakpoints = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  xxl: 1536,
+};
+
+export function useBreakpoints() {
+  const width = ref(window.innerWidth);
+
+  const updateWidth = () => {
+    width.value = window.innerWidth;
+  };
+
+  onMounted(() => {
+    window.addEventListener('resize', updateWidth);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('resize', updateWidth);
+  });
+
+  const currentSize = computed(() => {
+    if (width.value >= breakpoints.xxl) return 'xxl';
+    if (width.value >= breakpoints.xl) return 'xl';
+    if (width.value >= breakpoints.lg) return 'lg';
+    if (width.value >= breakpoints.md) return 'md';
+    if (width.value >= breakpoints.sm) return 'sm';
+    return 'xs';
+  });
+
+  return {
+    isSm: computed(() => currentSize.value === 'sm'),
+    isMd: computed(() => currentSize.value === 'md'),
+    isLg: computed(() => currentSize.value === 'lg'),
+    isXl: computed(() => currentSize.value === 'xl'),
+    isXXl: computed(() => currentSize.value === 'xxl'),
+    currentSize,
+  };
+}


### PR DESCRIPTION
This PR closes issue #642 

Adds a new composable function called `useBreakpoints` that provides support for responsive design. It allows the application to dynamically determine the current size of the viewport based on predefined breakpoints.

`useBreakpoints` examples return:

![image](https://github.com/user-attachments/assets/0623ad75-c88d-48c2-b82d-54cacd755282)
