### PR TITLE
Bugfix: fix Classes pages, update ClassTable component

### DIFF
--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -1,3 +1,14 @@
+<script>
+/**
+ * ClassTable.vue - Displays a class progression table with levels, features, proficiencies, and spell slots.
+ *
+ * @prop {Object} classFeatures - An object mapping class level (key) to class abilities (value)
+ * @prop {Object} proficiencyBonus - An object mapping character level (key) to prof. bonus (value)
+ * @prop {Array} spellSlots - A list of spell slot information per spell level (index = spell slot)
+ * @prop {Array} classResourceTableColumns - Extra columns for class-specific resources
+ */
+</script>
+
 <template>
   <table>
     <thead>

--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -73,8 +73,8 @@ const props = defineProps({
 
 // Parse proficiency bonuses
 const proficiencies = computed(() => {
-  if (!props?.proficiencyBonus?.keys().length > 0) return;
-  const { table_data: data } = props.proficiencyBonus[0];
+  if (!props?.proficiencyBonus?.table_data.length > 0) return;
+  const { table_data: data } = props.proficiencyBonus;
   return data.reduce((output, tableRow) => {
     output[tableRow.level] = tableRow.column_value;
     return output;

--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -29,10 +29,10 @@
       <td v-if="proficiencies">{{ proficiencies[level] ?? '-' }}</td>
 
       <!-- 3rd column: class features -->
-      <td v-if="!classFeatures[level]">–</td>
+      <td v-if="classFeatures && !classFeatures[level]">–</td>
       <td v-else>
         <span
-          v-for="feature in classFeatures[level]"
+          v-for="feature in classFeatures?.[level]"
           :key="feature.key"
           class="after:content-[',_'] last:after:content-['']"
         >
@@ -62,7 +62,7 @@ const props = defineProps({
 
 // Parse proficiency bonuses
 const proficiencies = computed(() => {
-  if (!props.proficiencyBonus) return;
+  if (!props?.proficiencyBonus?.keys().length > 0) return;
   const { table_data: data } = props.proficiencyBonus[0];
   return data.reduce((output, tableRow) => {
     output[tableRow.level] = tableRow.column_value;

--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -5,6 +5,9 @@
         <th rowspan="2">Level</th>
         <th v-if="proficiencies" rowspan="2">Proficiency Bonus</th>
         <th rowspan="2">Features</th>
+        <th v-for="title in additionalColumnHeaders" :key="title" rowspan="2">
+          {{ title }}
+        </th>
         <th
           v-if="spellslotColumnHeaders"
           :colspan="spellslotColumnHeaders.length"
@@ -37,6 +40,11 @@
         </span>
       </td>
 
+      <!-- Bonus columns for class specific resources -->
+      <td v-for="column in additionalColumnHeaders" :key="column">
+        {{ classResourceTableData[column][level] ?? '-' }}
+      </td>
+
       <td v-for="spellLevel in spellslotColumnHeaders" :key="spellLevel">
         {{ getSpellSlots(level, spellLevel) }}
       </td>
@@ -49,6 +57,7 @@ const props = defineProps({
   classFeatures: { type: Object, default: () => {} },
   proficiencyBonus: { type: Object, default: () => {} },
   spellSlots: { type: Array, default: () => [] },
+  classResourceTableColumns: { type: Array, default: () => [] },
 });
 
 // Parse proficiency bonuses
@@ -59,6 +68,25 @@ const proficiencies = computed(() => {
     output[tableRow.level] = tableRow.column_value;
     return output;
   }, Array(20));
+});
+
+// returns an array of additional columns used in this class's
+const additionalColumnHeaders = computed(() => {
+  if (props.classResourceTableColumns.length === 0) return;
+  return props.classResourceTableColumns.map((column) => column.name);
+});
+
+// parse additional class table data into a nested dict:
+// columnTitle -> level -> value
+const classResourceTableData = computed(() => {
+  return props.classResourceTableColumns.reduce((acc, column) => {
+    const { name: colName, table_data: valuePerLevel } = column;
+    if (!acc[colName]) acc[colName] = {};
+    valuePerLevel.forEach(({ level, column_value: value }) => {
+      acc[colName][level] = value;
+    });
+    return acc;
+  }, {});
 });
 
 // returns an array of table column headers for spell slots per level

--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -1,26 +1,33 @@
 <template>
   <table>
-    <tr>
-      <th>Level</th>
-      <th>Proficiency Bonus</th>
-      <th>Features</th>
-    </tr>
-    <tr v-for="(value, key, index) in classFeatures" :key="index">
-      <td>{{ key }}</td>
-      <td class="before:content-['+']">
-        {{ value['proficiency-bonus'] }}
-      </td>
-      <td>
+    <thead>
+      <tr>
+        <th>Level</th>
+        <th>Proficiency Bonus</th>
+        <th>Features</th>
+      </tr>
+    </thead>
+    <tr v-for="level in levels" :key="level">
+      <!-- 1st column: level -->
+      <td>{{ level }}</td>
+
+      <!-- 2nd column: proficiency bonus -->
+      <td>{{ proficiencies[level] ?? '-' }}</td>
+
+      <!-- 3rd column: class features -->
+      <td v-if="!classFeatures[level]">–</td>
+      <td v-else>
         <span
-          v-for="feature in value.features"
-          :key="feature"
-          class="capitalize after:content-[',_'] last:after:content-['']"
+          v-for="feature in classFeatures[level]"
+          :key="feature.key"
+          class="after:content-[',_'] last:after:content-['']"
         >
-          {{ parseFeatures(feature) }}
+          {{ feature.name + (feature.detail ? ` (${feature.detail})` : '') }}
         </span>
       </td>
     </tr>
   </table>
+
   <!-- TODO: Spell Slots - These are not currently returned by the API  -->
   <!-- Below is an exaple table column layout -->
   <!-- <table>
@@ -47,11 +54,22 @@
 </template>
 
 <script setup>
-defineProps({
+const props = defineProps({
   classFeatures: { type: Object, default: () => {} },
+  proficiencyBonus: { type: Object, default: () => {} },
+});
+
+const proficiencies = computed(() => {
+  const { table_data: data } = props.proficiencyBonus[0];
+  return data.reduce((output, tableRow) => {
+    output[tableRow.level] = tableRow.column_value;
+    return output;
+  }, Array(20));
 });
 
 // helper function for rendering reade-friendlt titles from feature keys
 const parseFeatures = (input) =>
   input.split('_').slice(-1).pop().split('-').join(' ');
+
+const levels = [...Array(20).keys()].map((i) => i + 1);
 </script>

--- a/pages/classes/[className]/[subclass].vue
+++ b/pages/classes/[className]/[subclass].vue
@@ -1,59 +1,12 @@
 <template>
-  <main v-if="classData" class="docs-container container">
-    <h1>{{ classData.name }}</h1>
-    <p v-if="classData.subclass_of">
-      <span class="font-bold after:content-['_']">Subclass of</span>
-      <!-- Key not rtn'd  by subclass_of, extract from url -->
-      <nuxt-link
-        class="font-bold"
-        :to="`/classes/${classData.subclass_of.url
-          .split('/')
-          .filter((exists) => exists)
-          .pop()}`"
-      >
-        {{ classData.subclass_of.name }}
-      </nuxt-link>
-    </p>
-
-    <section>
-      <h2>Class Features</h2>
-      <p>As a {{ classData.name }} you gain the following features.</p>
-
-      <section v-if="hitPoints.length > 0">
-        <h3>Hit Points</h3>
-        <dl>
-          <div v-for="item in hitPoints" :key="item.title">
-            <dt class="inline font-bold after:content-['_']">
-              {{ item.title }}
-            </dt>
-            <dd class="inline">{{ item.data }}</dd>
-          </div>
-        </dl>
-      </section>
-
-      <section v-if="proficiencies.length > 0">
-        <h3>Proficiencies</h3>
-        <dl>
-          <div v-for="prof in proficiencies" :key="prof.title">
-            <dt class="inline font-bold after:content-['_']">
-              {{ prof.title }}
-            </dt>
-            <dd class="inline">{{ prof.data }}</dd>
-          </div>
-        </dl>
-      </section>
-
-      <h3>The {{ classData.name }}</h3>
-      <class-table :class-features="classData.levels" />
-    </section>
-
+  <main v-if="subclassData" class="docs-container container">
+    <h1>{{ subclassData.name }}</h1>
     <!-- CLASS ABILITIES -->
     <section>
-      <h2>Class Abilities</h2>
-      <ul v-if="featuresInOrder.length > 0">
-        <li v-for="feature in featuresInOrder" :key="feature.key">
+      <ul v-if="features.length > 0">
+        <li v-for="feature in features" :key="feature.key">
           <h3>{{ feature.name }}</h3>
-          <md-viewer :text="feature.desc" header-level="3" />
+          <md-viewer :text="feature.desc" :header-level="3" />
         </li>
       </ul>
     </section>
@@ -63,84 +16,24 @@
 </template>
 
 <script setup>
-const { data: classData } = useFindOne(
+const { data: subclassData } = useFindOne(
   API_ENDPOINTS.classes,
   useRoute().params.subclass,
-  { params: { is_subclass: true } }
+  {
+    params: {
+      is_subclass: true,
+      subclass_of: useRoute().params.className,
+      depth: 1,
+      fields: ['name', 'key', 'features'].join(','),
+    },
+  }
 );
 
-// Formatting of fields is handled here to keep the template markup legible
-const hitPoints = computed(() => {
-  if (!classData.value.hit_points) {
-    return [];
-  }
-  return [
-    { title: 'Hit Dice', data: classData.value.hit_points.hit_dice_name },
-    {
-      title: 'Hit Points at 1st Level',
-      data: classData.value.hit_points.hit_points_at_1st_level,
-    },
-    {
-      title: 'Hit Points at Higher Levels',
-      data: classData.value.hit_points.hit_points_at_higher_levels,
-    },
-  ];
-});
-
-// TODO: proficiencies not currently returned by API
-const proficiencies = computed(() => {
-  if (!classData.value.proficiencies) {
-    return [];
-  }
-  return [
-    { title: 'Armor' },
-    { title: 'Weapons' },
-    { title: 'Tools' },
-    { title: 'Saving Throws' },
-    { title: 'Skills' },
-  ];
-});
-
-// ORDER CLASS FEATURES
-
-const featuresInOrder = computed(() => {
-  let levels = [];
-  for (let i = 1; i <= 20; i++) {
-    levels.push(i);
-  }
-
-  // get keys for features at each level
-  // returns an arr. (each index a level) of arrs. of keys
-  const featureKeysByLevel = levels.map(
-    (level) => classData.value.levels[level]?.features
+const features = computed(() => {
+  const features = subclassData.value.features;
+  if (!features) return [];
+  return [...features].sort(
+    (a, b) => a.gained_at[0].level - b.gained_at[0].level
   );
-
-  // take the keys per level and generate a 1D arr. of feature keys in order
-  let keysFound = [];
-  const featureKeysInOrder = featureKeysByLevel.reduce((acc, level) => {
-    // guard clause -> make sure there are features at this level
-    if (!level || level?.length === 0) {
-      return acc;
-    }
-
-    // flatten 2D array to an array of feature key w/ duplicates removed
-    const inOrder = level.reduce((acc, featureKey) => {
-      if (keysFound.includes(featureKey)) {
-        return acc;
-      }
-      keysFound.push(featureKey);
-      acc.push(featureKey);
-      return acc;
-    }, []);
-
-    return [...acc, ...(inOrder ?? [])];
-  }, []);
-
-  // use ordered feature keys to gather class data features in order
-  return featureKeysInOrder.map((keyToFind) => {
-    return classData.value.features.find(
-      (feautre) => feautre.key === keyToFind
-    );
-  });
 });
 </script>

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -96,7 +96,7 @@ const features = computed(() => {
   return featureData.reduce(
     (acc, feature) => {
       const { feature_type: type } = feature;
-      if (type === 'PROFICIENCY_BONUS') acc.proficiencyBonuses.push(feature);
+      if (type === 'PROFICIENCY_BONUS') acc.proficiencyBonuses = feature;
       else if (type === 'SPELL_SLOTS') acc.spellSlots.push(feature);
       else if (feature.table_data.length > 0)
         acc.classTableColumnData.push(feature);
@@ -109,7 +109,7 @@ const features = computed(() => {
     {
       classFeatures: [],
       proficiencies: [],
-      proficiencyBonuses: [],
+      proficiencyBonuses: undefined,
       startingEquipment: [],
       spellSlots: [],
       classTableColumnData: [],

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -53,6 +53,7 @@
       <class-table
         :class-features="formatFeaturesForTable(features.classFeatures)"
         :proficiency-bonus="features.proficiencyBonuses"
+        :spell-slots="features.spellSlots"
       />
     </section>
 
@@ -96,6 +97,7 @@ const features = computed(() => {
         acc.proficiencyBonuses.push(feature);
       else if (type === 'STARTING_EQUIPMENT')
         acc.startingEquipment.push(feature);
+      else if (type === 'SPELL_SLOTS') acc.spellSlots.push(feature);
       return acc;
     },
     {
@@ -103,6 +105,7 @@ const features = computed(() => {
       proficiencies: [],
       proficiencyBonuses: [],
       startingEquipment: [],
+      spellSlots: [],
     }
   );
 });

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -1,7 +1,6 @@
 <template>
   <main v-if="classData" class="docs-container container">
     <h1>{{ classData.name }}</h1>
-
     <ul v-if="subclasses.length > 0" class="mt-2">
       <p class="inline font-bold after:content-[':_']">Subclasses</p>
       <li v-for="subclass in subclasses" :key="subclass.name" class="inline">
@@ -54,6 +53,7 @@
         :class-features="formatFeaturesForTable(features.classFeatures)"
         :proficiency-bonus="features.proficiencyBonuses"
         :spell-slots="features.spellSlots"
+        :class-resource-table-columns="features.classTableColumnData"
       />
     </section>
 
@@ -91,13 +91,14 @@ const features = computed(() => {
   return featureData.reduce(
     (acc, feature) => {
       const { feature_type: type } = feature;
-      if (type === 'CLASS_FEATURE') acc.classFeatures.push(feature);
+      if (type === 'PROFICIENCY_BONUS') acc.proficiencyBonuses.push(feature);
+      else if (type === 'SPELL_SLOTS') acc.spellSlots.push(feature);
+      else if (feature.table_data.length > 0)
+        acc.classTableColumnData.push(feature);
+      else if (type === 'CLASS_FEATURE') acc.classFeatures.push(feature);
       else if (type === 'PROFICIENCIES') acc.proficiencies.push(feature);
-      else if (type === 'PROFICIENCY_BONUS')
-        acc.proficiencyBonuses.push(feature);
       else if (type === 'STARTING_EQUIPMENT')
         acc.startingEquipment.push(feature);
-      else if (type === 'SPELL_SLOTS') acc.spellSlots.push(feature);
       return acc;
     },
     {
@@ -106,6 +107,7 @@ const features = computed(() => {
       proficiencyBonuses: [],
       startingEquipment: [],
       spellSlots: [],
+      classTableColumnData: [],
     }
   );
 });

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -1,7 +1,18 @@
+<script>
+/**
+ * ClassTable.vue - Displays a class progression table with levels, features, proficiencies, and spell slots.
+ *
+ * @prop {Object} classFeatures - An object mapping class level (key) to class abilities (value)
+ * @prop {Object} proficiencyBonus - An object mapping character level (key) to prof. bonus (value)
+ * @prop {Array} spellSlots - A list of spell slot information per spell level (index = spell slot)
+ * @prop {Array} classResourceTableColumns - Extra columns for class-specific resources
+ */
+</script>
+
 <template>
   <main v-if="classData" class="docs-container container">
     <h1>{{ classData.name }}</h1>
-    <ul v-if="subclasses.length > 0" class="mt-2">
+    <ul v-if="subclasses?.length > 0" class="mt-2">
       <p class="inline font-bold after:content-[':_']">Subclasses</p>
       <li v-for="subclass in subclasses" :key="subclass.name" class="inline">
         <nuxt-link
@@ -28,7 +39,7 @@
       </div>
 
       <!-- Proficiencies -->
-      <div v-if="features.proficiencies.length > 0">
+      <div v-if="features?.proficiencies?.length > 0">
         <h3>Proficiencies</h3>
         <md-viewer
           v-for="proficiency in features.proficiencies"
@@ -36,7 +47,7 @@
           :text="proficiency.desc"
         />
       </div>
-      <div v-if="features.startingEquipment.length > 0">
+      <div v-if="features?.startingEquipment?.length > 0">
         <h3>Equipment</h3>
         <md-viewer
           v-for="equipment in features.startingEquipment"
@@ -75,7 +86,12 @@
 const { data: classData } = useFindOne(
   API_ENDPOINTS.classes,
   useRoute().params.className,
-  { params: { is_subclass: false } }
+  {
+    params: {
+      is_subclass: false,
+      fields: ['name', 'key', 'subclasses', 'features'].join(),
+    },
+  }
 );
 
 // fetch subclasses to generate links
@@ -152,6 +168,7 @@ const featureToStubs = (feature) => {
 };
 
 const formatFeaturesForTable = (features) => {
+  if (!features || features?.length === 0) return {};
   return features.reduce((output, feature) => {
     const featureStubs = featureToStubs(feature);
     featureStubs.forEach((stub) => {
@@ -163,15 +180,16 @@ const formatFeaturesForTable = (features) => {
 };
 
 // transforms the classFeatures arr into an obj. that maps levels to features
-const featuresPerLevel = computed(() =>
-  features.value.classFeatures.reduce((output, feature) => {
+const featuresPerLevel = computed(() => {
+  if (!features?.value?.classFeatures) return {};
+  return features.value.classFeatures.reduce((output, feature) => {
     const featureLevel = findFeatureLowestLevel(feature);
     if (!featureLevel) return output;
     if (!output[featureLevel]) output[featureLevel] = [feature];
     else output[featureLevel].push(feature);
     return output;
-  }, {})
-);
+  }, {});
+});
 
 // flattens the featuresPerLevel obj to create array of features sorted by lvl
 const featuresInOrder = computed(() =>

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -50,7 +50,10 @@
     <!-- Class Table -->
     <section>
       <h2>The {{ classData.name }}</h2>
-      <class-table :class-features="classData.levels" />
+      <class-table
+        :class-features="formatFeaturesForTable(features.classFeatures)"
+        :proficiency-bonus="features.proficiencyBonuses"
+      />
     </section>
 
     <!-- Class Abilities -->
@@ -123,7 +126,7 @@ const hitPoints = computed(() => {
 });
 
 // helper - takes an ability and if it gained at multiple lvls rtrns the lowest
-const findFeatureLevel = (feature) => {
+const findFeatureLowestLevel = (feature) => {
   const gainedAt = feature.gained_at;
   if (gainedAt.length === 0) return;
   if (gainedAt.length === 1) return gainedAt[0].level;
@@ -133,10 +136,31 @@ const findFeatureLevel = (feature) => {
   return lowestLevel;
 };
 
+// takes a feature and returns an array item for every lvl in the gained_at field
+const featureToStubs = (feature) => {
+  const { gained_at: gainedAt } = feature;
+  return gainedAt.map((atLevel) => ({
+    name: feature.name,
+    detail: atLevel.detail,
+    level: atLevel.level,
+  }));
+};
+
+const formatFeaturesForTable = (features) => {
+  return features.reduce((output, feature) => {
+    const featureStubs = featureToStubs(feature);
+    featureStubs.forEach((stub) => {
+      if (!output[stub.level]) output[stub.level] = [stub];
+      else output[stub.level].push(stub);
+    });
+    return output;
+  }, {});
+};
+
 // transforms the classFeatures arr into an obj. that maps levels to features
 const featuresPerLevel = computed(() =>
   features.value.classFeatures.reduce((output, feature) => {
-    const featureLevel = findFeatureLevel(feature);
+    const featureLevel = findFeatureLowestLevel(feature);
     if (!featureLevel) return output;
     if (!output[featureLevel]) output[featureLevel] = [feature];
     else output[featureLevel].push(feature);

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -1,14 +1,3 @@
-<script>
-/**
- * ClassTable.vue - Displays a class progression table with levels, features, proficiencies, and spell slots.
- *
- * @prop {Object} classFeatures - An object mapping class level (key) to class abilities (value)
- * @prop {Object} proficiencyBonus - An object mapping character level (key) to prof. bonus (value)
- * @prop {Array} spellSlots - A list of spell slot information per spell level (index = spell slot)
- * @prop {Array} classResourceTableColumns - Extra columns for class-specific resources
- */
-</script>
-
 <template>
   <main v-if="classData" class="docs-container container">
     <h1>{{ classData.name }}</h1>

--- a/tests/unit/pages/class.test.tsx
+++ b/tests/unit/pages/class.test.tsx
@@ -2,7 +2,7 @@ import { test, expect } from 'vitest';
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime';
 import ClassPage from '~/pages/classes/[className]/index.vue';
 
-const { data: className } = useFindOne('v2/classes', 'srd_fighter');
+const { data: className } = useFindOne('v2/classes', 'srd_barbarian');
 
 const page = await mountSuspended(ClassPage);
 
@@ -19,184 +19,120 @@ test('/classes/[className] page renders title', async () => {
 mockNuxtImport('useFindOne', () => {
   return () => ({
     data: {
-      url: 'http://localhost:8000/v2/classes/srd_barbarian/',
       key: 'srd_barbarian',
-      hit_points: {
-        hit_dice: 'd12',
-        hit_dice_name: '1d12 per Barbarian level',
-        hit_points_at_1st_level: '12 + your Constitution modifier',
-        hit_points_at_higher_levels:
-          '1d12 (or 7) + your Constitution modifier per barbarian level after 1st',
-      },
-      name: 'Barbarian',
-      hit_dice: 'd12',
-      document: 'http://localhost:8000/v2/documents/srd/',
-      subclass_of: null,
       features: [
         {
-          key: 'srd_barbarian_ability-score-improvement',
-          name: 'Ability Score Improvement',
-          desc: 'When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above 20 using this feature.',
+          key: 'srd_barbarian_proficiencies',
+          name: 'Proficiencies',
+          desc: '**Armor:** Light armor, medium armor, shields\n\n**Weapons:** Simple weapons, martial weapons\n\n**Tools:** None\n\n**Saving Throws:** Strength, Constitution\n\n**Skills:** Choose two from Animal Handling, Athletics, Intimidation, Nature, Perception, and Survival',
+          gained_at: [],
+          table_data: [],
+          feature_type: 'PROFICIENCIES',
         },
         {
-          key: 'srd_barbarian_brutal-critical',
-          name: 'Brutal Critical',
-          desc: 'Beginning at 9th level, you can roll one additional weapon damage die when determining the extra damage for a critical hit with a melee attack.\r\n\r\nThis increases to two additional dice at 13th level and three additional dice at 17th level.',
-        },
-        {
-          key: 'srd_barbarian_danger-sense',
-          name: 'Danger Sense',
-          desc: 'At 2nd level, you gain an uncanny sense of when things nearby aren’t as they should be, giving you an edge when you dodge away from danger.\r\n\r\nYou have advantage on Dexterity saving throws against effects that you can see, such as traps and spells. To gain this benefit, you can’t be blinded, deafened, or incapacitated.',
-        },
-        {
-          key: 'srd_barbarian_extra-attack',
-          name: 'Extra Attack',
-          desc: 'Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn.',
-        },
-        {
-          key: 'srd_barbarian_fast-movement',
-          name: 'Fast Movement',
-          desc: 'Starting at 5th level, your speed increases by 10 feet while you aren’t wearing heavy armor.',
-        },
-        {
-          key: 'srd_barbarian_feral-instinct',
-          name: 'Feral Instinct',
-          desc: 'By 7th level, your instincts are so honed that you have advantage on initiative rolls.\r\n\r\nAdditionally, if you are surprised at the beginning of combat and aren’t incapacitated, you can act normally on your first turn, but only if you enter your rage before doing anything else on that turn.',
-        },
-        {
-          key: 'srd_barbarian_indomitable-might',
-          name: 'Indomitable Might',
-          desc: 'Beginning at 18th level, if your total for a Strength check is less than your Strength score, you can use that score in place of the total.',
-        },
-        {
-          key: 'srd_barbarian_persistent-rage',
-          name: 'Persistent Rage',
-          desc: 'Beginning at 15th level, your rage is so fierce that it ends early only if you fall unconscious or if you choose to end it.',
-        },
-        {
-          key: 'srd_barbarian_primal-champion',
-          name: 'Primal Champion',
-          desc: 'At 20th level, you embody the power of the wilds. Your Strength and Constitution scores increase by 4. Your maximum for those scores is now 24.',
-        },
-        {
-          key: 'srd_barbarian_primal-path',
-          name: 'Primal Path',
-          desc: 'At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels.',
+          key: 'srd_barbarian_proficiency-bonus',
+          name: 'Proficiency Bonus',
+          desc: '[Column data]',
+          gained_at: [],
+          table_data: [
+            {
+              level: 1,
+              column_value: '+2',
+            },
+            {
+              level: 10,
+              column_value: '+4',
+            },
+            {
+              level: 11,
+              column_value: '+4',
+            },
+            {
+              level: 12,
+              column_value: '+4',
+            },
+            {
+              level: 13,
+              column_value: '+5',
+            },
+            {
+              level: 14,
+              column_value: '+5',
+            },
+            {
+              level: 15,
+              column_value: '+5',
+            },
+            {
+              level: 16,
+              column_value: '+5',
+            },
+            {
+              level: 17,
+              column_value: '+6',
+            },
+            {
+              level: 18,
+              column_value: '+6',
+            },
+            {
+              level: 19,
+              column_value: '+6',
+            },
+            {
+              level: 2,
+              column_value: '+2',
+            },
+            {
+              level: 20,
+              column_value: '+6',
+            },
+            {
+              level: 3,
+              column_value: '+2',
+            },
+            {
+              level: 4,
+              column_value: '+2',
+            },
+            {
+              level: 5,
+              column_value: '+3',
+            },
+            {
+              level: 6,
+              column_value: '+3',
+            },
+            {
+              level: 7,
+              column_value: '+3',
+            },
+            {
+              level: 8,
+              column_value: '+3',
+            },
+            {
+              level: 9,
+              column_value: '+4',
+            },
+          ],
+          feature_type: 'PROFICIENCY_BONUS',
         },
         {
           key: 'srd_barbarian_rage',
           name: 'Rage',
-          desc: "In battle, you fight with primal ferocity. On your turn, you can enter a rage as a bonus action.\r\n\r\nWhile raging, you gain the following benefits if you aren't wearing heavy armor:\r\n\r\n* You have advantage on Strength checks and Strength saving throws.\r\n* When you make a melee weapon attack using Strength, you gain a bonus to the damage roll that increases as you gain levels as a barbarian, as shown in the Rage Damage column of the Barbarian table.\r\n* You have resistance to bludgeoning, piercing, and slashing damage. \r\n\r\nIf you are able to cast spells, you can't cast them or concentrate on them while raging.\r\n\r\nYour rage lasts for 1 minute. It ends early if you are knocked unconscious or if your turn ends and you haven't attacked a hostile creature since your last turn or taken damage since then. You can also end your rage on your turn as a bonus action.\r\n\r\nOnce you have raged the number of times shown for your barbarian level in the Rages column of the Barbarian table, you must finish a long rest before you can rage again.",
-        },
-        {
-          key: 'srd_barbarian_reckless-attack',
-          name: 'Reckless Attack',
-          desc: 'Starting at 2nd level, you can throw aside all concern for defense to attack with fierce desperation. When you make your first attack on your turn, you can decide to attack recklessly. Doing so gives you advantage on melee weapon attack rolls using Strength during this turn, but attack rolls against you have advantage until your next turn.',
-        },
-        {
-          key: 'srd_barbarian_relentless-rage',
-          name: 'Relentless Rage',
-          desc: 'Starting at 11th level, your rage can keep you fighting despite grievous wounds. If you drop to 0 hit points while you’re raging and don’t die outright, you can make a DC 10 Constitution saving throw. If you succeed, you drop to 1 hit point instead.\r\n\r\nEach time you use this feature after the first, the DC increases by 5. When you finish a short or long rest, the DC resets to 10.',
-        },
-        {
-          key: 'srd_barbarian_unarmored-defense',
-          name: 'Unarmored Defense',
-          desc: 'While you are not wearing any armor, your Armor Class equals 10 + your Dexterity modifier + your Constitution modifier. You can use a shield and still gain this benefit.',
+          desc: "In battle, you fight with primal ferocity. On your turn, you can enter a rage as a bonus action.\n\n\n\nWhile raging, you gain the following benefits if you aren't wearing heavy armor:\n\n\n\n* You have advantage on Strength checks and Strength saving throws.\n\n* When you make a melee weapon attack using Strength, you gain a bonus to the damage roll that increases as you gain levels as a barbarian, as shown in the Rage Damage column of the Barbarian table.\n\n* You have resistance to bludgeoning, piercing, and slashing damage. \n\n\n\nIf you are able to cast spells, you can't cast them or concentrate on them while raging.\n\n\n\nYour rage lasts for 1 minute. It ends early if you are knocked unconscious or if your turn ends and you haven't attacked a hostile creature since your last turn or taken damage since then. You can also end your rage on your turn as a bonus action.\n\n\n\nOnce you have raged the number of times shown for your barbarian level in the Rages column of the Barbarian table, you must finish a long rest before you can rage again.",
+          gained_at: [
+            {
+              level: 1,
+              detail: null,
+            },
+          ],
+          table_data: [],
+          feature_type: 'CLASS_FEATURE',
         },
       ],
-      levels: {
-        '12': {
-          features: ['srd_barbarian_ability-score-improvement'],
-          'proficiency-bonus': 4,
-          level: 12,
-        },
-        '16': {
-          features: ['srd_barbarian_ability-score-improvement'],
-          'proficiency-bonus': 5,
-          level: 16,
-        },
-        '19': {
-          features: ['srd_barbarian_ability-score-improvement'],
-          'proficiency-bonus': 6,
-          level: 19,
-        },
-        '4': {
-          features: ['srd_barbarian_ability-score-improvement'],
-          'proficiency-bonus': 2,
-          level: 4,
-        },
-        '8': {
-          features: ['srd_barbarian_ability-score-improvement'],
-          'proficiency-bonus': 3,
-          level: 8,
-        },
-        '13': {
-          features: ['srd_barbarian_brutal-critical'],
-          'proficiency-bonus': 5,
-          level: 13,
-        },
-        '17': {
-          features: ['srd_barbarian_brutal-critical'],
-          'proficiency-bonus': 6,
-          level: 17,
-        },
-        '9': {
-          features: ['srd_barbarian_brutal-critical'],
-          'proficiency-bonus': 4,
-          level: 9,
-        },
-        '2': {
-          features: [
-            'srd_barbarian_danger-sense',
-            'srd_barbarian_reckless-attack',
-          ],
-          'proficiency-bonus': 2,
-          level: 2,
-        },
-        '5': {
-          features: [
-            'srd_barbarian_extra-attack',
-            'srd_barbarian_fast-movement',
-          ],
-          'proficiency-bonus': 3,
-          level: 5,
-        },
-        '7': {
-          features: ['srd_barbarian_feral-instinct'],
-          'proficiency-bonus': 3,
-          level: 7,
-        },
-        '18': {
-          features: ['srd_barbarian_indomitable-might'],
-          'proficiency-bonus': 6,
-          level: 18,
-        },
-        '15': {
-          features: ['srd_barbarian_persistent-rage'],
-          'proficiency-bonus': 5,
-          level: 15,
-        },
-        '20': {
-          features: ['srd_barbarian_primal-champion'],
-          'proficiency-bonus': 6,
-          level: 20,
-        },
-        '3': {
-          features: ['srd_barbarian_primal-path'],
-          'proficiency-bonus': 2,
-          level: 3,
-        },
-        '1': {
-          features: ['srd_barbarian_rage', 'srd_barbarian_unarmored-defense'],
-          'proficiency-bonus': 2,
-          level: 1,
-        },
-        '11': {
-          features: ['srd_barbarian_relentless-rage'],
-          'proficiency-bonus': 4,
-          level: 11,
-        },
-      },
+      name: 'Barbarian',
     },
   });
 });
@@ -205,8 +141,8 @@ mockNuxtImport('useFindMany', () => {
   return () => ({
     data: [
       {
-        key: 'srd_champion',
-        name: 'Champion',
+        key: 'srd_barbarian',
+        name: 'Barbarian',
       },
     ],
   });


### PR DESCRIPTION
Closes #627 

This PR addresses problems that occured on the `/classes/[className]` and `/classes/[className]/[subclass]` routes due to recent changes made to the `/v2/classes` API endpoint. 

- `/pages/classes/[className]/index.vue` was updated to correctly parse the updated data format returned by the API. It seperates out proficiencies, starting equipment, and other class features that typically go at the top of the class page from the class features gained at X level, which go toward the bottom.
- The `<ClassTable>` component was updated to work with the new data format returned by the API
- `/pages/classes/[className]/[subclass]/index.vue` was updated to work with new API data format