### PR TITLE
Task: Hide Size Column of Monsters Overview on Mobile v2 - fix the filter style

### DIFF
--- a/components/ApiTableFilter.vue
+++ b/components/ApiTableFilter.vue
@@ -27,7 +27,7 @@
       v-for="field in selectFields"
       :key="field.name"
       class="grid columns-1 justify-center"
-      :class="{ 'hidden sm:block': field.isLeastPriority }"
+      :class="{ 'hidden sm:grid': field.isLeastPriority }"
     >
       <label class="font-serif text-xs" :for="field.name">
         {{ field.name }}


### PR DESCRIPTION
This PR is the fix the side effect of PR #641.

BEFORE: 
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/83daa64d-fe8b-49bd-b519-c16a43738142" />

AFTER:
<img width="1482" alt="image" src="https://github.com/user-attachments/assets/f2971faa-e4de-40cd-a7ba-7f70331cfb46" />
