### PR TITLE
Feature: add UI to top-level pages for displaying number of entries per source returned by API

### DIFF
--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="grid items-center justify-end gap-2">
-    <div class="grid grid-flow-col grid-cols-5 gap-1">
-      <div class="col-start-3 place-self-center font-bold">
+    <ul class="grid grid-flow-col grid-cols-5 gap-1">
+      <li class="col-start-3 place-self-center font-bold">
         {{ pageNumber }}
-      </div>
-      <div v-for="button in buttons" :key="button.name">
+      </li>
+      <li v-for="button in buttons" :key="button.name">
         <ApiTableButton
           :name="button.name"
           :icon="button.icon"
@@ -12,8 +12,8 @@
           class="mt-1 border-2"
           @click="button.onClick()"
         />
-      </div>
-    </div>
+      </li>
+    </ul>
 
     <div class="text-center font-bold">
       {{ (pageNumber - 1) * itemsPerPage + 1 }} to

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -17,12 +17,16 @@
       </li>
     </ul>
 
-    <div class="text-center text-sm font-bold">
-      {{ (pageNumber - 1) * itemsPerPage + 1 }} -
-      {{
-        lastPageNumber === pageNumber ? totalItems : pageNumber * itemsPerPage
-      }}
-      / {{ totalItems }}
+    <div class="grid grid-cols-[2fr,_1fr,_2fr] text-center text-xs">
+      <span class="mr-2 text-center">
+        {{ (pageNumber - 1) * itemsPerPage + 1 }}
+        <span class="font-bold">–</span>
+        {{
+          lastPageNumber === pageNumber ? totalItems : pageNumber * itemsPerPage
+        }}
+      </span>
+      <span class="mx-4 font-bold">&frasl;</span>
+      <span class="text-center">{{ totalItems }}</span>
     </div>
   </div>
 </template>

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -43,28 +43,24 @@ const buttons = [
     isActive: isNotFirstPage,
     onClick: () => emit('first'),
     icon: 'heroicons:chevron-double-left',
-    class: 'col-start-1',
   },
   {
     name: 'Previous page',
     isActive: isNotFirstPage,
     onClick: () => emit('prev'),
     icon: 'heroicons:chevron-left',
-    class: 'col-start-2',
   },
   {
     name: 'Next page',
     isActive: isNotLastPage,
     onClick: () => emit('next'),
     icon: 'heroicons:chevron-right',
-    class: 'col-start-4',
   },
   {
     name: 'Last page',
     isActive: isNotLastPage,
     onClick: () => emit('last'),
     icon: 'heroicons:chevron-double-right',
-    class: 'col-start-5',
   },
 ];
 </script>

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="grid justify-end">
-    <ul class="flex">
-      <li v-for="button in buttons" :key="button.name">
+  <div class="grid items-center justify-end gap-2">
+    <div class="grid grid-flow-col grid-cols-5 gap-1">
+      <div class="col-start-3 place-self-center font-bold">
+        {{ pageNumber }}
+      </div>
+      <div v-for="button in buttons" :key="button.name">
         <ApiTableButton
           :name="button.name"
           :icon="button.icon"
@@ -9,17 +12,24 @@
           class="mt-1 border-2"
           @click="button.onClick()"
         />
-      </li>
-    </ul>
-    <label class="block text-center font-bold">
-      {{ `${pageNumber} of ${lastPageNumber}` }}
-    </label>
+      </div>
+    </div>
+
+    <div class="text-center font-bold">
+      {{ (pageNumber - 1) * itemsPerPage + 1 }} to
+      {{
+        lastPageNumber === pageNumber ? totalItems : pageNumber * itemsPerPage
+      }}
+      of {{ totalItems }}
+    </div>
   </div>
 </template>
 <script setup>
 const props = defineProps({
   lastPageNumber: { type: Number, default: 1 },
   pageNumber: { type: Number, default: 1 },
+  itemsPerPage: { type: Number, default: 1 },
+  totalItems: { type: Number, default: 1 },
 });
 const emit = defineEmits(['first', 'last', 'next', 'prev']);
 
@@ -33,24 +43,28 @@ const buttons = [
     isActive: isNotFirstPage,
     onClick: () => emit('first'),
     icon: 'heroicons:chevron-double-left',
+    class: 'col-start-1',
   },
   {
     name: 'Previous page',
     isActive: isNotFirstPage,
     onClick: () => emit('prev'),
     icon: 'heroicons:chevron-left',
+    class: 'col-start-2',
   },
   {
     name: 'Next page',
     isActive: isNotLastPage,
     onClick: () => emit('next'),
     icon: 'heroicons:chevron-right',
+    class: 'col-start-4',
   },
   {
     name: 'Last page',
     isActive: isNotLastPage,
     onClick: () => emit('last'),
     icon: 'heroicons:chevron-double-right',
+    class: 'col-start-5',
   },
 ];
 </script>

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="grid items-center justify-end gap-2">
+  <div class="grid w-full items-center justify-end gap-2">
     <ul class="grid grid-flow-col grid-cols-5 gap-1">
       <li class="col-start-3 place-self-center font-bold">
         {{ pageNumber }}

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -1,8 +1,10 @@
 <template>
-  <div class="grid w-full items-center justify-end gap-2">
+  <div class="grid w-full items-center justify-end">
     <ul class="grid grid-flow-col grid-cols-5 gap-1">
       <li class="col-start-3 place-self-center font-bold">
-        {{ pageNumber }}
+        <sup>{{ pageNumber }}</sup>
+        <span>&frasl;</span>
+        <sub>{{ lastPageNumber }}</sub>
       </li>
       <li v-for="button in buttons" :key="button.name">
         <ApiTableButton
@@ -15,12 +17,12 @@
       </li>
     </ul>
 
-    <div class="text-center font-bold">
-      {{ (pageNumber - 1) * itemsPerPage + 1 }} to
+    <div class="text-center text-sm font-bold">
+      {{ (pageNumber - 1) * itemsPerPage + 1 }} -
       {{
         lastPageNumber === pageNumber ? totalItems : pageNumber * itemsPerPage
       }}
-      of {{ totalItems }}
+      / {{ totalItems }}
     </div>
   </div>
 </template>

--- a/composables/useFindPaginated.ts
+++ b/composables/useFindPaginated.ts
@@ -97,6 +97,7 @@ export const useFindPaginated = (options: {
       lastPage,
       pageNo,
       lastPageNo,
+      itemsPerPage,
     },
   };
 };

--- a/pages/backgrounds/index.vue
+++ b/pages/backgrounds/index.vue
@@ -7,6 +7,8 @@
         class="w-full"
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -48,6 +50,13 @@ const { data, paginator } = useFindPaginated({
 });
 
 // destructure pagination controls
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/classes/index.vue
+++ b/pages/classes/index.vue
@@ -6,6 +6,8 @@
         class="w-full"
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -62,6 +64,13 @@ const { data, paginator } = useFindPaginated({
 });
 
 // destructure pagination controls
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/conditions/index.vue
+++ b/pages/conditions/index.vue
@@ -7,6 +7,8 @@
         class="w-full"
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -39,6 +41,13 @@ const { data, paginator } = useFindPaginated({
 });
 
 // destructure pagination controls
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/equipment/index.vue
+++ b/pages/equipment/index.vue
@@ -6,6 +6,8 @@
       <ApiTableNav
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -99,6 +101,13 @@ const { data, paginator } = useFindPaginated({
   },
 });
 
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/feats/index.vue
+++ b/pages/feats/index.vue
@@ -7,6 +7,8 @@
         class="w-full"
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -46,6 +48,13 @@ const { data, paginator } = useFindPaginated({
   },
 });
 
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/magic-items/index.vue
+++ b/pages/magic-items/index.vue
@@ -6,6 +6,8 @@
       <ApiTableNav
         :page-number="pageNo || 1"
         :last-page-number="lastPageNo || 1"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -114,6 +116,13 @@ const { data, paginator } = useFindPaginated({
 });
 
 // destructure pagination controls
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/monsters/index.vue
+++ b/pages/monsters/index.vue
@@ -7,6 +7,8 @@
         class="w-full"
         :page-number="pageNo || 1"
         :last-page-number="lastPageNo || 1"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -132,6 +134,13 @@ const { data, paginator } = useFindPaginated({
 });
 
 // destructure pagination controls
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/races/index.vue
+++ b/pages/races/index.vue
@@ -7,6 +7,8 @@
         class="w-full"
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -46,6 +48,13 @@ const { data, paginator } = useFindPaginated({
   },
 });
 
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/rules/index.vue
+++ b/pages/rules/index.vue
@@ -7,6 +7,8 @@
         class="w-full"
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -62,6 +64,13 @@ const { data, paginator } = useFindPaginated({
   },
 });
 
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>

--- a/pages/spells/index.vue
+++ b/pages/spells/index.vue
@@ -7,6 +7,8 @@
         class="w-full"
         :page-number="pageNo"
         :last-page-number="lastPageNo"
+        :items-per-page="itemsPerPage || 1"
+        :total-items="data?.count || 1"
         @first="firstPage()"
         @next="nextPage()"
         @prev="prevPage()"
@@ -138,6 +140,13 @@ const { data, paginator } = useFindPaginated({
 });
 
 // destructure pagination controls
-const { pageNo, lastPageNo, firstPage, lastPage, prevPage, nextPage } =
-  paginator;
+const {
+  pageNo,
+  lastPageNo,
+  itemsPerPage,
+  firstPage,
+  lastPage,
+  prevPage,
+  nextPage,
+} = paginator;
 </script>


### PR DESCRIPTION
This PR close issue #644 

- [x] See how many entries are returned by the endpoint (perhaps rendered near to the page controls?) 
- [x] See a breakdown of how many entries are returned from each source document selected.
- [x] Wrap it up in some nice UI that fits in with the rest of the website.

Screenshots:
First Page
<img width="1471" alt="image" src="https://github.com/user-attachments/assets/a9b4844d-8f59-4bac-a8e4-a17b010211fa" />

Second Page
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/569bcc04-aca6-4a52-beb0-d448b1086d44" />

Last Page
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/2b0fe4ca-b359-4016-b703-bdc89e17cbf2" />

Responsive
<img width="408" alt="image" src="https://github.com/user-attachments/assets/76a39145-dad3-455e-b9f3-d1ad8e8b293a" />
<img width="653" alt="image" src="https://github.com/user-attachments/assets/3de1cefa-5311-4073-baac-ba1d1883bda7" />

Latest update based on the comment from @calumbell 
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/66eb603b-20e9-4917-bbfe-6b0230c7296d" />

<img width="662" alt="image" src="https://github.com/user-attachments/assets/84244193-e456-4c1a-b450-504631dc9a3d" />


