### PR TITLE
Added `useDicerRoller()` to monster ability recharge

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -249,9 +249,10 @@
             <span>{{ action.name }}</span>
             <span
               v-if="action.uses_type === 'RECHARGE_ON_ROLL'"
-              class="before:content-['_']"
+              class="cursor-pointer font-bold text-blood before:text-black before:content-['_('] after:text-black after:content-[')'] hover:text-black dark:before:text-white dark:after:text-white dark:hover:text-white"
+              @click="useDiceRoller('1d6+0')"
             >
-              {{ `(Recharge ${action.uses_param}-6)` }}
+              {{ `Recharge ${action.uses_param}-6` }}
             </span>
           </span>
           <md-viewer :inline="true" :text="action.desc" :use-roller="true" />


### PR DESCRIPTION
Closes #629 

Recharge information that is displayed on certain actions of monster stat blocks now use the `useDiceRoller()` composable to created rollable links.


From the Monstrous Menagerie Adult Brass Dragon statblock:


<img width="833" alt="Screenshot 2025-03-09 at 09 52 34" src="https://github.com/user-attachments/assets/3b9a97ae-10c7-41ba-995e-49277167553d" />


<img width="835" alt="Screenshot 2025-03-09 at 09 52 44" src="https://github.com/user-attachments/assets/56ce134a-bf33-438f-9e26-aa62381c7c7b" />
