### PR TITLE
Improve Component Documentation

### DIFF
--- a/components/ApiResultRow.vue
+++ b/components/ApiResultRow.vue
@@ -1,3 +1,22 @@
+<script>
+/**
+ * ApiResultRow.vue -> Sub-component of ApiResultsTable. Displays a single
+ * result returned by the API as a a table row (<tr> element). Typically
+ * contains a link to the single-view page of the API resource.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Object} data – data for a single item from the Open5e API
+ * @prop {Array} cols – an array specifying which table columns to render:
+ *   @property {String} displayName – column name formatted to display
+ *   @property {String} sortValue – column name (used for sorting)
+ *   @property {Boolean?} isLeastPriority – (optional) controls whether this
+ *      column is hidden on small screen
+ *
+ * -= DEPENDENCIES =-
+ * @component SourceTag – renders doucment source UI
+ */
+</script>
+
 <template>
   <tr>
     <!-- Render each field defined in columns as a table cell -->
@@ -24,7 +43,6 @@
     </td>
   </tr>
 </template>
-
 <script setup>
 const props = defineProps({
   data: { type: Object, default: () => {} }, // Open5e data to render

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -1,3 +1,25 @@
+<script>
+/**
+ * ApiResultsTable.vue - Displays a sortable list of data returned by the Open5e API
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Object} data - API data to display
+ * @prop {Number} [itemsPerPage=50] - The number of API results to display per page
+ * @prop {Array} col - Array of column definitions, each containing:
+ *   @property {String} field - The field name (used for sorting)
+ *   @property {String} displayName - The name to display in the column header
+ * @prop {String} [sortBy="name"] – The column to sort by (compares against col.field)
+ * @prop {Boolean} isSortDescending – Controls sort direction
+ *
+ * -= EMITS (OUTPUTS) =-
+ * @emits {String} sort – Emit the sorting value when a column is sorted
+ *
+ * -= DEPENDENCIES =-
+ * <ApiResultRow> -> render table rows (refac'd into own cmpnt for readibility)
+ * <SortableTableHeader> -> captures logic for column headers
+ */
+</script>
+
 <template>
   <div>
     <table v-if="data" class="m-0 w-full">

--- a/components/ApiResultsTable.vue
+++ b/components/ApiResultsTable.vue
@@ -1,6 +1,7 @@
 <script>
 /**
- * ApiResultsTable.vue - Displays a sortable list of data returned by the Open5e API
+ * ApiResultsTable.vue - Displays a sortable list of data returned by the Open5e
+ * API. Used on top-level pages where lists of results can be viewed.
  *
  * -= PROPS (INPUTS) =-
  * @prop {Object} data - API data to display
@@ -15,8 +16,9 @@
  * @emits {String} sort – Emit the sorting value when a column is sorted
  *
  * -= DEPENDENCIES =-
- * <ApiResultRow> -> render table rows (refac'd into own cmpnt for readibility)
- * <SortableTableHeader> -> captures logic for column headers
+ * This component uses the following sub-components
+ * @component ApiResultRow -> render table rows (refac'd into own cmpnt for readibility)
+ * @component SortableTableHeader -> captures logic for column headers
  */
 </script>
 

--- a/components/ApiTableButton.vue
+++ b/components/ApiTableButton.vue
@@ -1,12 +1,19 @@
-<script setup>
-defineProps({
-  disabled: Boolean,
-  name: { type: String, required: true },
-  icon: { type: String, required: true },
-  sizeClasses: { type: String, default: 'w-8 h-8' },
-});
-
-defineEmits(['click']);
+<script>
+/**
+ * ApiTableButton - customizable button that displays an icon and can be clicked to trigger events.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Boolean} disabled - Controls whether the button is disabled
+ * @prop {String} name - Button name/label, used for accessibility
+ * @prop {String} icon - The name of the icon to be displayed inside the button.
+ * @prop {String} sizeClasses - TailwindCSS classes to overwrite default size
+ *
+ * -= EMITS (OUTPUTS) =-
+ * @emits click - Emits a click event when the button is clicked.
+ *
+ * -= DEPENDENCIES =-
+ * @component Icon -> Renders an icon based on the provided `icon` prop.
+ */
 </script>
 
 <template>
@@ -24,3 +31,14 @@ defineEmits(['click']);
     <Icon :name="icon" />
   </button>
 </template>
+
+<script setup>
+defineProps({
+  disabled: Boolean,
+  name: { type: String, required: true },
+  icon: { type: String, required: true },
+  sizeClasses: { type: String, default: 'w-8 h-8' },
+});
+
+defineEmits(['click']);
+</script>

--- a/components/ApiTableFilter.vue
+++ b/components/ApiTableFilter.vue
@@ -1,3 +1,41 @@
+<script>
+/**
+ * ApiTableFilter.vue - Displays a set of filter controls for filtering data
+ * returned by the Open5e API.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Object} filterState - The state of the filters, returned by
+ * `useFilterState()` composable.
+ *   @property {Object} fieldsState - The current values of the filter fields.
+ *   @property {Object} canClearFilter - Flag for whether filter can be cleared
+ *   @method {Function} updateField - Function to update the value of a filter field.
+ *   @method {Function} clearFilter - Function to clear the active filter.
+ *
+ * @prop {Object} [search] - Configuration for the search filter.
+ *   @property {String} name - The name of the search field.
+ *   @property {String} filterField - The filter field for the search.
+ *
+ * @prop {Array} selectFields - Fields to be filtered using drop-down menus
+ *   @property {String} name - Display name of the field - what the use sees.
+ *   @property {String} filterField - The filter field to be updated.
+ *   @property {Array} options - Dropdown filter options/choices
+ *   @property {Boolean} [isLeastPriority] - Flag to hide fields on small screens.
+ *
+ * @prop {Array} checkboxFields - Fields to be filtered using checkboxes
+ *   @property {String} name - The name of the checkbox field (displayed in label).
+ *   @property {String} filterField - The filter field for the checkbox.
+ *
+ * -= EMITS (OUTPUTS) =-
+ * @emits {String} updateField – Emit the updated field value when a filter is changed.
+ * @emits {Boolean} clearFilter – Emit when the filter is cleared.
+ *
+ * -= DEPENDENCIES =-
+ * @component Icon -> Renders icons in the UI.
+ * @component ApiTableButton -> Button for clearing the filter.
+ *
+ */
+</script>
+
 <template>
   <div class="my-2 flex items-end justify-between gap-2 md:gap-3">
     <!-- RENDER SEARCH BAR -->
@@ -92,7 +130,7 @@
   </div>
 </template>
 
-<script setup lang="ts">
+<script setup>
 // TODO: Set up types for these props once ESLint supports use of defineProps<> so we can pass in generics for the filters we're using
 const props = defineProps({
   filterState: { type: Object, required: true }, // This is the return value of useFilterState // TODO: When ESLint supports defineProps<> we could type this properly

--- a/components/ApiTableNav.vue
+++ b/components/ApiTableNav.vue
@@ -1,3 +1,25 @@
+<script>
+/**
+ * ApiTableNav.vue - Pagination controls, designed to be used with the
+ * `<ApiResultsTable />` component
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Number} lastPageNumber - Last page number
+ * @prop {Number} pageNumber - Current page number
+ * @prop {Number} itemsPerPage - The number of items displayed per page
+ * @prop {Number} totalItems - The total number of items across all pages
+ *
+ * -= EMITS (OUTPUTS) =-
+ * @emits first - Emitted when "first page" button clicked
+ * @emits last - Emitted when "last page" button clicked
+ * @emits next - Emitted when "next page" button clicked
+ * @emits prev - Emitted when "prev page" button clicked
+ *
+ * -= DEPENDENCIES =-
+ * @component ApiTableButton – Renders pagination buttons with icons.
+ */
+</script>
+
 <template>
   <div class="grid w-full items-center justify-end">
     <ul class="grid grid-flow-col grid-cols-5 gap-1">

--- a/components/BreadcrumbLinks.vue
+++ b/components/BreadcrumbLinks.vue
@@ -1,3 +1,20 @@
+<script>
+/**
+ * BreadcrumbLinks.vue - A breadcrumb navigation component that displays a hierarchical navigation path.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Array} crumbs - An array of breadcrumb objects, each containing:
+ *   @property {String} url - The URL target of the link
+ *   @property {String} title - The title to display for the breadcrumb.
+ *   @property {String} [subtitle] - Optional subtitle to display after title
+ *     in parentheses.
+ *
+ * -= DEPENDENCIES =-
+ * @component Icon – rendered the 'home' icon next to the link to site index
+ * @composable useBreadcrumbs – generates breadcrumbs from the current URL
+ */
+</script>
+
 <template>
   <nav
     class="flex h-min items-center dark:border-basalt"

--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -1,10 +1,17 @@
 <script>
 /**
- * ClassTable.vue - Displays a class progression table with levels, features, proficiencies, and spell slots.
+ * ClassTable.vue - Displays a table of class progression data - for each level
+ * features, proficiencies, and spell slots are rendered.
  *
- * @prop {Object} classFeatures - An object mapping class level (key) to class abilities (value)
- * @prop {Object} proficiencyBonus - An object mapping character level (key) to prof. bonus (value)
- * @prop {Array} spellSlots - A list of spell slot information per spell level (index = spell slot)
+ * -= PROPS / INPUTS =-
+ * @prop {Object} classFeatures -  Maps class level (key) to abilities gained
+ * at that level (value).
+ *  @property {Object} classFeatures[level] - Array of features per class level
+ *     @property {String} feature.key - The unique key for the feature
+ *     @property {String} feature.name - Display name for the feature
+ *     @property {String} [feature.detail] - Additional contextual information
+ * @prop {Object} proficiencyBonus - Maps char. level (key) to prof. bonus (value)
+ * @prop {Array} spellSlots - Spell slot information per spell level
  * @prop {Array} classResourceTableColumns - Extra columns for class-specific resources
  */
 </script>

--- a/components/CrossLink.global.vue
+++ b/components/CrossLink.global.vue
@@ -1,7 +1,20 @@
-<!--
-  This component is global so that the markdown parser can see it and parse the
-  cross-link tags as components. There might be a better way to handle this
--->
+<script>
+/**
+ * CrossLink - An inline link to an Open5e resource. Fetches & displays a
+ *   preview of the linked resource when hovered
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {String} src - The source of the Open5e resource being linked to. The
+ *   resources endpoint and key can be extracted from it.
+ *
+ *
+ * -= DEPENDENCIES =-
+ * @component LinkPreview – Displays a preview of the linked content.
+ * @axios - Fetches API data (TODO: replace /w Vue Query)
+ *
+ */
+</script>
+
 <template>
   <nuxt-link
     v-if="acceptibleTypes.includes(category)"
@@ -37,9 +50,7 @@ const url = computed(() => {
   const { altFrontEndSubroute, apiEndpoint } = paramsByType[category.value];
 
   // make sure that category has a recognised endpoint
-  if (!apiEndpoint) {
-    return { linkTarget: '/' };
-  }
+  if (!apiEndpoint) return { linkTarget: '/' };
 
   // FE uses section's parent for routing. Update url once data is fetched
   if (content.value && category.value === 'sections') {

--- a/components/InlineRoller.global.vue
+++ b/components/InlineRoller.global.vue
@@ -1,3 +1,19 @@
+<script>
+/**
+ * InlineRoller - creates a clickable dice roller link. Essentially a UI
+ * wrapper for the `useDiceRoller` composable. Global so that is can be
+ * inserted into Markdown via the `MdViewer` component.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {String} signature - Dice signature (ie. 1d6+3) to pass to the
+ *   `useDiceRoller` composable.
+ *
+ * -= DEPENDENCIES =-
+ * @composable useDiceRoller – parses dice signatures and handles dice rolling
+ *
+ */
+</script>
+
 <template>
   <span
     class="cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
@@ -7,7 +23,7 @@
   </span>
 </template>
 
-<script lang="ts" setup>
+<script setup>
 const props = defineProps({
   signature: { type: String, default: '' },
 });

--- a/components/LinkPreview.vue
+++ b/components/LinkPreview.vue
@@ -1,3 +1,16 @@
+<script>
+/**
+ * LinkPreview - A card that displays detailed information about a specific category of content.
+ *
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {String} category - What type of content the preview is linking to.
+ *   Different types of Open5e resources need different data in the preview
+ * @prop {Object} content - content to render on the card. varies with category
+ *
+ */
+</script>
+
 <template>
   <article
     class="absolute top--1 z-10 hidden h-max bg-slate-100 px-4 py-3 text-black shadow-md dark:bg-basalt dark:text-white md:group-hover:block"

--- a/components/MdViewer.vue
+++ b/components/MdViewer.vue
@@ -1,5 +1,28 @@
+<script>
+/**
+ * MdViewer.vue - Renders Markdown content as HTML. Essentially a wrapper for
+ * the VueShowdown library with a few extensions for parsing certain custom
+ * Markdown tags as custom Nuxt components (via the "extentions" prop)
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Boolean} toc - A boolean flag to control whether a Table of Contents
+ *   is generated or not.
+ * @prop {String} text - Markdown string to be converted to HTML.
+ * @prop {Number} headerLevel - The header level to start from for the Markdown
+ *   content. Used for MD nested deeply in a parent doc. Defaults to `1` -> h1
+ * @prop {Boolean} inline - Flag. Enables rendering inline markdown.
+ * @prop {Boolean} useRoller - Whether to parse dice sigs as rollable on click
+ *
+ *
+ * -= DEPENDENCIES =-
+ * - @component VueShowdown: The Markdown rendering library. Converts MD -> HTML
+ * - @component CrossLink: Inserted into HTML in place of <open5e-link> tag in MD
+ * - @component InlineRoller: Inserted into HTML
+ */
+</script>
+
 <template ref="el">
-  <vue-showdown
+  <VueShowdown
     ref="mdwrapper"
     :vue-template="true"
     :options="{

--- a/components/ModalDialog.vue
+++ b/components/ModalDialog.vue
@@ -1,3 +1,30 @@
+<script>
+/**
+ * ModalDialog.vue - A modal dialog component that displays a centered overlay.
+ * Contents and Action buttons are created by passing slots to component.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Boolean} open - controls whether the modal is open or closed
+ *
+ * -= SLOTS =-
+ * @slot default - modal main content, injected inside the modal body
+ * @slot actions - A named slot for placing action buttons in the modal footer
+ *
+ * -= EMITS (OUTPUTS) =-
+ * @emits {Boolean} close - Emits `true` when the modal is closed, so the
+ *   parent component can update the modal state.
+ * @emits {Boolean} update:open - Emits `false` to update the `open` prop to
+ *   `false` when the modal is closed.
+ *
+ * -= DEPENDENCIES =-
+ * @component Dialog – from @headlessui/vue: creates a modal menu
+ * @component DialogPanel – from @headlessui/vue: creates the panel of modal
+ * @component TransitionChild – from @headlessui/vue: creates transition effects
+ * @component TransitionRoot – from @headlessui/vue: controls the root transition
+ *
+ */
+</script>
+
 <template>
   <TransitionRoot as="template" :show="open" @key.escape="closeModal">
     <Dialog as="div" class="relative z-100" @close="closeModal">

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -1,3 +1,17 @@
+<script>
+/**
+ * NavBar.vue - Navigation sidebar. Renders a list of links w/ optional nesting
+ *
+ * -= PROPS (INPUTS) =-
+ * None (but perhaps `routes` should be a prop).
+ *
+ * -= DEPENDENCIES =-
+ * @composable useFindMany: data-fetching composable. Fetches `Classes` to populate menu
+ * @composable useRoute: Nuxt composable. Used to highlight current route.
+ *
+ */
+</script>
+
 <template>
   <ul class="text-inherit text-white">
     <li v-for="section in routes" :key="section.title">

--- a/components/NavLink.vue
+++ b/components/NavLink.vue
@@ -1,3 +1,19 @@
+<script>
+/**
+ * NavLink.vue - Custom link designed to be used with the <NavBar>. Handles
+ * styles, current route highlighting, and optional indentation.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {String} to - URL tag of the link
+ * @prop {String} title - Link title (currently not used in the template)
+ * @prop {Boolean} indent - A flag to apply additional indentation
+ *
+ * -= SLOTS =-
+ * @slot default - The content to be as the Link's body
+ *
+ */
+</script>
+
 <template>
   <nuxt-link
     :class="`bold block w-full px-4  text-white hover:bg-slate-800/40 hover:underline

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -1,3 +1,16 @@
+<script>
+/**
+ * PageNotifications.vue - A UI wrapper for the `notifications` singleton
+ * returned by the useNotifications composable. Displays notifications in the
+ * lower right corner of the window
+ *
+ * -= DEPENDENCIES =-
+ * - @composable useNotifications: manages notification state and actions.
+ * - @composable useRoute: detect route changes (& clears notifs)
+ *
+ */
+</script>
+
 <template>
   <div class="absolute bottom-0 right-8 m-0 flex flex-col-reverse p-0">
     <div

--- a/components/ReportIssue.vue
+++ b/components/ReportIssue.vue
@@ -1,3 +1,21 @@
+<script>
+/**
+ * ReportIssue.vue - A button that opens a modal menu for users to submit
+ * website issues via a GoogleSheet
+ *
+ * -= PROPS (INPUTS) =-
+ * This component does not receive any props.
+ *
+ * -= EMITS =-
+ * @emit close: Emitted when the modal is closed. Used by parent to control
+ * modal visibility
+ *
+ * -= DEPENDENCIES =-
+ * @component ModalDialogue: Displays the issue form as a modal menu
+ *
+ */
+</script>
+
 <script setup>
 import { ref } from 'vue';
 const isOpen = ref(false);

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -1,4 +1,26 @@
-<!-- SearchResults is designed to take a single row returned by the /search API endpoint and return a list item containing a link to a page -->
+<script>
+/**
+ * SearchResults.vue - Renders a single item returned by the /search endpoint.
+ *   Returns an `<li>` element to be placed in a list of other results.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {String} query - The search query. Used for highlighting matching text
+ *   in the result snippet.
+ * @prop {Object} result - A single search result rtn'd by /search endpoint
+ *   @property {String} result.object_name - The name of the result returned
+ *   @property {String} result.object_model - result's type (ie. Spell, Item)
+ *   @property {Object} result.object - Extra data about the search result,
+ *     varies depending on the `object_model`.
+ *   @property {Object} result.document - result's source: includes 'key' and 'name'.
+ *   @property {String} result.object_pk - Results UID
+ *   @property {String} result.highlighted - highlighted snippet for result
+ *
+ * -= DEPENDENCIES =-
+ * @component SourceTag – Renders info about document source of search result
+ * @component MdViewer – Renders Markdown as HTML
+ *
+ */
+</script>
 
 <template>
   <li class="py-2 text-base">

--- a/components/SidebarToggle.vue
+++ b/components/SidebarToggle.vue
@@ -1,3 +1,14 @@
+<script>
+/**
+ * SidebarToggle - Displays a circular hamburger-menu style button
+ *
+ * -= DEPENDENCIES =-
+ * @component Icon - renders an icon based on the `name` prop (hard-coded as
+ *   `"heroicons:bars-3"`)
+ *
+ */
+</script>
+
 <template>
   <button
     class="flex h-10 w-10 items-center justify-center rounded-full bg-fog hover:bg-smoke dark:bg-basalt hover:dark:bg-granite"

--- a/components/SortableTableHeader.vue
+++ b/components/SortableTableHeader.vue
@@ -1,3 +1,26 @@
+<script>
+/**
+ * SortableTableHeader.vue - A table header cell that includes sorting functionality. It displays a title with a sorting indicator (▲/▼),
+ *   allowing users to sort the table by the corresponding column.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {String} title - Column title, appears in table header
+ * @prop {String} sortBy - `key` in data to sort by when clicked. If omitted,
+ *   then sorting by this column will be disabled.
+ * @prop {Boolean} isSortingProperty - True if this col is currently sorting the
+ *   table. It is used to highlight the sorting indicator.
+ * @prop {Boolean} isSortDescending - Specifies sort direction. Controls
+ *   direction of the sort indicator (▲/▼).
+ * @prop {Boolean} isLeastPriority - If true, hide this col on small screens
+ *
+ * -= EMITS (OUTPUTS) =-
+ * @emits {String} sort - Emits the `sortBy` key when user clicks the column
+ *   header. Used to update data on parent component
+ *
+ *
+ */
+</script>
+
 <template>
   <th
     :aria-sort="isSortDescending"

--- a/components/SourceTag.vue
+++ b/components/SourceTag.vue
@@ -1,3 +1,18 @@
+<script>
+/**
+ * SourceTag.vue - Renders a colorful bubble containing infomation about an
+ * item from the Open5e API's source document. Inline, designed by follow the
+ * title of the API result.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {String} text - Text displayed on the tag. Typically a source's 'key'
+ * @prop {String} title - Tooltip text that appears on hover
+ * @prop {String} textColor - text color of tag
+ * @prop {String} background - background color of tag
+ * @prop {String} border - border color of tag
+ */
+</script>
+
 <template>
   <span
     :class="['tag-element', 'font-sans', 'font-medium', 'ml-2']"

--- a/components/SourcesModal.vue
+++ b/components/SourcesModal.vue
@@ -1,3 +1,25 @@
+<script>
+/**
+ * SourceSelectionModal.vue - Displays a modal for selecting sources, grouped by publisher, with options
+ *   to select/deselect all sources and filter by game system.
+ *
+ * -= PROPS (INPUTS) =-
+ * @prop {Object} sources - List of currently selected sources pulled
+ * @prop {Function} setSources - Function to update the selected sources in the parent component.
+ * @prop {String} gameSystem - The currently selected game system.
+ * @prop {Function} setGameSystem - Function to update the selected game system in the parent component.
+ *
+ * -= EMITS (OUTPUTS) =-
+ * @emits {Function} close – Emit when the modal should be closed.
+ * @emits {Function} saveSelection – Emit when the user confirms the selection and the modal should close.
+ *
+ * -= DEPENDENCIES =-
+ * @component ModalDialogue – Used for rendering the modal dialog UI.
+ * @component SourceTag – Displays a tag for each source showing relevant information.
+ *
+ */
+</script>
+
 <template>
   <modal-dialog @close="closeModal()">
     <slot>

--- a/components/ThemeSwitcher.vue
+++ b/components/ThemeSwitcher.vue
@@ -19,7 +19,5 @@
 </template>
 
 <script setup lang="ts">
-import { useThemeSwitcher } from '~/composables/useThemeSwitcher';
-
 const { theme, toggleTheme } = useThemeSwitcher();
 </script>


### PR DESCRIPTION
Closes #638

This PR drastically improves component documentation on the repo, and hopefully provides a template for the documentation of future components.

Here is an example of the new documentation scheme from the `ApiResultsTable` component:

```
<script>
/**
 * ApiResultsTable.vue - Displays a sortable list of data returned by the Open5e
 * API. Used on top-level pages where lists of results can be viewed.
 *
 * -= PROPS (INPUTS) =-
 * @prop {Object} data - API data to display
 * @prop {Number} [itemsPerPage=50] - The number of API results to display per page
 * @prop {Array} col - Array of column definitions, each containing:
 *   @property {String} field - The field name (used for sorting)
 *   @property {String} displayName - The name to display in the column header
 * @prop {String} [sortBy="name"] – The column to sort by (compares against col.field)
 * @prop {Boolean} isSortDescending – Controls sort direction
 *
 * -= EMITS (OUTPUTS) =-
 * @emits {String} sort – Emit the sorting value when a column is sorted
 *
 * -= DEPENDENCIES =-
 * This component uses the following sub-components
 * @component ApiResultRow -> render table rows (refac'd into own cmpnt for readibility)
 * @component SortableTableHeader -> captures logic for column headers
 */
</script>
```

JS comments are placed in an additional `<script>` tag at the top of the component, far away from the business end. A short component overview and brief descriptions of Props, Emits, Dependencies, and (where applicable) Slots are included.