### PR TITLE
Base- and sub-classes on NavBar

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -14,19 +14,35 @@
 
 <template>
   <ul class="text-inherit text-white">
+    <TestComponent />
+    <!-- Render top-level links -->
     <li v-for="section in routes" :key="section.title">
-      <nav-link :to="section.route">
+      <nav-link :to="section.url">
         {{ section.title }}
       </nav-link>
+
+      <!-- Render sub-routes -->
       <ul
         v-if="section.subroutes"
-        v-show="path.indexOf(section.route) != -1"
+        v-show="crumbs?.[0]?.title === section.title"
         class="bg-slate-800/30 py-2"
       >
-        <li v-for="page in section.subroutes" :key="page.key">
-          <nav-link :to="`${section.route}/${page.key}`" :indent="true">
-            {{ page.name }}
+        <li v-for="subroute in section.subroutes" :key="subroute.title">
+          <nav-link :to="`${subroute.url}`" :indentation-level="1">
+            {{ subroute.title }}
           </nav-link>
+
+          <!-- Render sub-sub routes (and no deeper) -->
+          <ul>
+            <li
+              v-for="subSubroute in subroute.subroutes"
+              :key="subSubroute.title"
+            >
+              <nav-link :to="`${subSubroute.url}`" :indentation-level="2">
+                {{ subSubroute.title }}
+              </nav-link>
+            </li>
+          </ul>
         </li>
       </ul>
     </li>
@@ -34,59 +50,93 @@
 </template>
 
 <script setup>
-import { useRoute } from 'nuxt/app';
-const { path } = useRoute();
-
 const { data: classes } = useFindMany(API_ENDPOINTS.classes, {
-  fields: ['name', 'key'].join(),
-  is_subclass: false,
+  fields: ['name', 'key', 'subclass_of'].join(),
+});
+
+const crumbs = useBreadcrumbs();
+
+// Conditionally generates additional links to base- and sub- classes
+const classSubroutes = computed(() => {
+  if (!classes?.value) return;
+  // only generate subroutes if we are on a child route of '/classes'
+  if (crumbs.value?.[0]?.title !== 'Classes') return;
+
+  // split classes into base- and sub-classes
+  const [baseClasses, subClasses] = classes.value.reduce(
+    (acc, val) => {
+      if (!val['subclass_of']) return [[...acc[0], val], [...acc[1]]];
+      else return [[...acc[0]], [...acc[1], val]];
+    },
+    [[], []]
+  );
+
+  // generate subroutes to other base-classes
+  let output = baseClasses.map((item) => {
+    return { title: item.name, url: `/classes/${item.key}` };
+  });
+
+  // if we are on a sub-route of a base-class, get other sub-class routes
+  if (crumbs.value.length >= 2) {
+    const baseClass = crumbs.value[1];
+    const subClassesForClass = subClasses
+      .filter((item) => item?.['subclass_of']?.includes(baseClass.src))
+      .map((item) => {
+        const url = `/classes/${baseClass.src}/${item.key}`;
+        return { title: item.name, url };
+      });
+    output[output.findIndex((el) => el.title === baseClass.title)].subroutes =
+      subClassesForClass;
+  }
+
+  return output;
 });
 
 const routes = computed(() => [
   {
     title: 'Classes',
-    route: '/classes',
-    subroutes: classes.value ?? [],
+    url: '/classes',
+    subroutes: classSubroutes.value,
   },
   {
     title: 'Races',
-    route: '/races',
+    url: '/races',
   },
   {
     title: 'Monsters',
-    route: '/monsters',
+    url: '/monsters',
   },
   {
     title: 'Magic Items',
-    route: '/magic-items',
+    url: '/magic-items',
   },
   {
     title: 'Spells',
-    route: '/spells',
+    url: '/spells',
   },
   {
     title: 'Backgrounds',
-    route: '/backgrounds',
+    url: '/backgrounds',
   },
   {
     title: 'Feats',
-    route: '/feats',
+    url: '/feats',
   },
   {
     title: 'Equipment',
-    route: '/equipment',
+    url: '/equipment',
   },
   {
     title: 'Conditions',
-    route: '/conditions',
+    url: '/conditions',
   },
   {
     title: 'Rules',
-    route: '/rules',
+    url: '/rules',
   },
   {
     title: 'API Docs',
-    route: '/api-docs',
+    url: '/api-docs',
   },
 ]);
 </script>

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -14,7 +14,6 @@
 
 <template>
   <ul class="text-inherit text-white">
-    <TestComponent />
     <!-- Render top-level links -->
     <li v-for="section in routes" :key="section.title">
       <nav-link :to="section.url">

--- a/components/NavLink.vue
+++ b/components/NavLink.vue
@@ -6,7 +6,7 @@
  * -= PROPS (INPUTS) =-
  * @prop {String} to - URL tag of the link
  * @prop {String} title - Link title (currently not used in the template)
- * @prop {Boolean} indent - A flag to apply additional indentation
+ * @prop {Number} indentationLevel - How deeply should the navlink be indented
  *
  * -= SLOTS =-
  * @slot default - The content to be as the Link's body
@@ -16,11 +16,15 @@
 
 <template>
   <nuxt-link
-    :class="`bold block w-full px-4  text-white hover:bg-slate-800/40 hover:underline
-      dark:hover:bg-slate-600/40 ${
-        useRoute().fullPath.includes(to) && 'bg-slate-800 font-bold'
-      } ${indent && 'py-1 pl-8'} ${!indent && 'py-3'}
-      `"
+    class="bold block w-full px-4 hover:bg-slate-800/40 hover:underline dark:hover:bg-slate-600/40"
+    :class="
+      [
+        useRoute().fullPath.includes(to) && 'bg-slate-800 font-bold',
+        indentationLevel === 0 && 'py-3',
+        indentationLevel === 1 && 'py-1 pl-6',
+        indentationLevel === 2 && 'py-1 pl-10 text-sm',
+      ].join(' ')
+    "
     :to="to"
   >
     <slot />
@@ -28,7 +32,7 @@
 </template>
 
 <script setup>
-defineProps({
+const props = defineProps({
   to: {
     type: String,
     default: '',
@@ -37,9 +41,9 @@ defineProps({
     type: String,
     default: '',
   },
-  indent: {
-    type: Boolean,
-    default: false,
+  indentationLevel: {
+    type: Number,
+    default: 0,
   },
 });
 </script>

--- a/composables/useBreadcrumbs.ts
+++ b/composables/useBreadcrumbs.ts
@@ -5,6 +5,7 @@ type Breadcrumb = {
   url: string;
   title: string;
   subtitle: string;
+  src: string;
 };
 
 export const useBreadcrumbs = () => {
@@ -26,6 +27,7 @@ export const useBreadcrumbs = () => {
           return {
             ...generateTitles(pathSegment),
             url,
+            src: pathSegment,
           } as Breadcrumb;
         })
 


### PR DESCRIPTION
Closes #507 

This PR adds extends the functionality to the `NavBar` component by condtionally including links to base- and sub-classes.

- Base classes are visible when the user visits `/classes` route, or any of its children.
- Sub-classes are visible when the user visits the sub-class's base-class, or any of its other sub-classes.

<img width="697" alt="Screenshot 2025-03-23 at 16 40 05" src="https://github.com/user-attachments/assets/40cd8d48-1b9a-4ffe-904b-51c58cadb62e" />
