### PR TITLE
Bugfix: `Recharge 6-6` -> `Recharge 6` on monster statblock actions

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -218,7 +218,10 @@
             class="cursor-pointer font-bold text-blood before:text-black before:content-['_('] after:text-black after:content-[')_'] hover:text-black dark:before:text-white dark:after:text-white dark:hover:text-white"
             @click="useDiceRoller('1d6+0')"
           >
-            {{ `Recharge ${action.uses_param}-6` }}
+            {{
+              'Recharge ' +
+              (action.uses_param < 6 ? `${action.uses_param}-6` : '6')
+            }}
           </span>
           <md-viewer inline="true" :text="action.desc" :use-roller="true" />
         </li>


### PR DESCRIPTION
Closes #664 

This PR fixes a UI bug on the `/monsters/[id]` page where actions with a recharge roll of 6 were displaying `"Recharge 6-6"` instead of `"Recharge 6"`. This was fixed by added a ternary that only includes the the "X-" only when a recharge roll is less than 6.

From `/monsters/bfrd_adult-green-dragon`

<img width="663" alt="Screenshot 2025-03-24 at 08 42 20" src="https://github.com/user-attachments/assets/77b2f370-1691-4e97-96d9-e40df11f265b" />
