### PR TITLE
Commas between rollable skills/saves now match page text styles

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -115,7 +115,7 @@
         <li
           v-for="(save, name) in monster.saving_throws"
           :key="name"
-          class="inline cursor-pointer font-bold text-blood after:content-[',_'] last:after:content-[] hover:text-black dark:hover:text-fog"
+          class="inline cursor-pointer font-bold text-blood after:text-black after:content-[',_'] last:after:content-[] hover:text-black dark:after:text-white dark:hover:text-fog"
           @click="useDiceRoller(save.toString())"
         >
           {{ `${name.toUpperCase().slice(0, 3)} ${useFormatModifier(save)}` }}
@@ -130,7 +130,7 @@
         <li
           v-for="(modifier, skill) in monster.skill_bonuses"
           :key="skill"
-          class="inline cursor-pointer font-bold capitalize text-blood after:content-[',_'] last:after:content-[] hover:text-black dark:hover:text-fog"
+          class="inline cursor-pointer font-bold capitalize text-blood after:text-black after:content-[',_'] last:after:content-[] hover:text-black dark:after:text-white dark:hover:text-fog"
           @click="useDiceRoller(modifier.toString())"
         >
           {{ `${skill} ${useFormatModifier(modifier)}` }}


### PR DESCRIPTION
Closes #622 

Commas between rollable dice signatures that follow a monster's skills or saving throw proficiencies now have the same text color as the rest of the document text.

<img width="664" alt="Screenshot 2025-03-25 at 09 58 27" src="https://github.com/user-attachments/assets/d11c1469-a768-4914-a351-b25d0c2f1e4c" />
<img width="682" alt="Screenshot 2025-03-25 at 10 00 51" src="https://github.com/user-attachments/assets/ab1dd80b-958c-4f8f-9124-7040d80320f4" />
