### PR TITLE
Bugfix/layout wide styles

### DIFF
--- a/assets/_docs.scss
+++ b/assets/_docs.scss
@@ -94,22 +94,6 @@ table {
     );
     border: 0;
   }
-  p,
-  ul,
-  dt,
-  hr,
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  section {
-    max-width: 40rem;
-  }
-  th:first-child {
-    min-width: 4rem;
-  }
 }
 
 h2.filter-header {
@@ -122,5 +106,4 @@ blockquote {
   border-left: 0.75rem solid #999;
   padding: 0.1rem 1rem 1rem 1rem;
   margin-top: 1rem;
-  max-width: 40rem;
 }

--- a/components/PageNotifications.vue
+++ b/components/PageNotifications.vue
@@ -12,14 +12,16 @@
 </script>
 
 <template>
-  <div class="absolute bottom-0 right-8 m-0 flex flex-col-reverse p-0">
+  <div class="fixed bottom-0 right-8 m-0 flex min-w-36 flex-col-reverse p-0">
     <div
       v-if="notifications.length"
-      class="flex gap-2 bg-white/80 dark:bg-darkness/80"
+      class="grid justify-end bg-white/80 dark:bg-darkness/80"
     >
-      <h2 class="my-0 text-lg">Notifications</h2>
-      <button class="font-bold text-blood hover:text-red-400" @click="clear()">
-        Clear
+      <button
+        class="mr-2 font-bold text-blood hover:text-red-400"
+        @click="clear()"
+      >
+        Clear All &#x2715;
       </button>
     </div>
     <ul class="flex flex-col">

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,13 +1,15 @@
 <template>
-  <div class="overflow-hidden text-darkness">
+  <div
+    class="grid justify-center overflow-hidden bg-fog bg-[radial-gradient(#ddd_1px,transparent_1px)] [background-size:16px_16px] dark:bg-darkness dark:bg-[radial-gradient(#222_1px,transparent_1px)]"
+  >
     <sources-modal :show="showModal" @close="showModal = false" />
     <div
-      class="grid h-screen w-screen grid-flow-col bg-white transition-all dark:bg-darkness sm:ml-0 sm:grid-cols-[14rem_1fr] sm:overflow-y-auto sm:transition-none"
-      :class="showSidebar ? 'ml-0' : '-ml-56'"
+      class="bg-dark m-auto grid h-full min-h-screen max-w-[1280px] grid-flow-col transition-all sm:ml-0 sm:w-screen sm:grid-cols-[14rem_1fr] sm:overflow-y-auto sm:transition-none"
+      :class="showSidebar ? 'ml-56' : '-ml-56'"
     >
       <!-- Sidebar -->
       <div
-        class="z-50 flex w-56 flex-col overflow-y-auto bg-slate-700 text-white dark:bg-slate-900"
+        class="z-50 flex h-full w-56 flex-col overflow-y-auto bg-slate-700 text-white dark:bg-charcoal"
       >
         <!-- Logo -->
         <nuxt-link

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,4 +1,6 @@
 <template>
+  <!-- BACKGROUND (visible behind page content at wide screen widths)       -->
+  <!-- bg-radial-gradiant arbitrary classes generate the dotted bg pattern  -->
   <div
     class="grid justify-center overflow-hidden bg-fog bg-[radial-gradient(#ddd_1px,transparent_1px)] [background-size:16px_16px] dark:bg-darkness dark:bg-[radial-gradient(#222_1px,transparent_1px)]"
   >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -42,6 +42,7 @@ module.exports = {
         granite: '#888',
         // gray: '#767676', // this conflicts with an existing tailwind class
         basalt: '#333',
+        charcoal: '#222',
         darkness: '#111',
       },
 


### PR DESCRIPTION
## Description

This PR improves the site-wide page layout at larger screen widths. Negative space has been moved from the centre of the page to the sides at wide page sizes, flanking the main page content. The background behind the main content has a subtle dotted pattern that helps the deliniate fore- and back-ground.

Most of the changes involved updating TailwindCSS styles in the `/layouts/default.vue` component.

Some additional work was required to remove conflicting SCSS classes from the `assets/_docs.scss` that were interferring with the new layout. Also, the PageNotifications component needed to be updated so that pop-ups would be positioned correctly in the new layout.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Documentation update
- [ ] Other (please specify):

## Related Issue

Closes #669 

## How has this been tested?

The changes have been tested manually on a local test server (see screenshots) - data was pulled from a Django test server running the current `staging` branch of the Open5e API.

The following commands execute without error:
- `npm run test`
- `npm run build`
- `npm run generate`

## Screenshots

Home page (light mode)
<img width="1631" alt="Screenshot 2025-03-30 at 10 48 04" src="https://github.com/user-attachments/assets/1e2b7fac-81b4-4055-9b1f-ea22fa45c796" />

Home page (dark mode)
<img width="1632" alt="Screenshot 2025-03-30 at 10 47 50" src="https://github.com/user-attachments/assets/8a7f175b-8cf1-4429-8251-942234b3d23f" />

Monster list (light mode)
<img width="1631" alt="Screenshot 2025-03-30 at 10 48 15" src="https://github.com/user-attachments/assets/02aee1a5-30b9-4086-9531-c4b51841b678" />

Monster list (dark mode)
<img width="1631" alt="Screenshot 2025-03-30 at 10 48 25" src="https://github.com/user-attachments/assets/a84e3b83-d852-4769-b8a5-ee45683724c9" />

