### PR TITLE
Features in ClassTable now link to their full description

### DIFF
--- a/components/ClassTable.vue
+++ b/components/ClassTable.vue
@@ -13,6 +13,9 @@
  * @prop {Object} proficiencyBonus - Maps char. level (key) to prof. bonus (value)
  * @prop {Array} spellSlots - Spell slot information per spell level
  * @prop {Array} classResourceTableColumns - Extra columns for class-specific resources
+ *
+ *  -= DEPENDENCIES =-
+ *  @function titleCaseToKebabCase – "Title Case" -> "kebab-case". Used to generate hash-links
  */
 </script>
 
@@ -50,11 +53,19 @@
       <td v-if="classFeatures && !classFeatures[level]">–</td>
       <td v-else>
         <span
-          v-for="feature in classFeatures?.[level]"
-          :key="feature.key"
-          class="after:content-[',_'] last:after:content-['']"
+          v-for="(feature, index) in classFeatures?.[level]"
+          :key="feature.name"
         >
-          {{ feature.name + (feature.detail ? ` (${feature.detail})` : '') }}
+          <NuxtLink
+            :key="feature.key"
+            :to="'#' + titleCaseToKebabCase(feature.name)"
+          >
+            {{ feature.name + (feature.detail ? ` (${feature.detail})` : '') }}
+          </NuxtLink>
+          <!-- insert commas between features -->
+          <span v-if="index !== classFeatures[level].length - 1">
+            {{ ', ' }}
+          </span>
         </span>
       </td>
 
@@ -71,6 +82,7 @@
 </template>
 
 <script setup>
+import { titleCaseToKebabCase } from '~/functions/titleCaseToKebabCase';
 const props = defineProps({
   classFeatures: { type: Object, default: () => {} },
   proficiencyBonus: { type: Object, default: () => {} },

--- a/composables/useBreadcrumbs.ts
+++ b/composables/useBreadcrumbs.ts
@@ -16,9 +16,8 @@ export const useBreadcrumbs = () => {
         .split('/')
         .map((pathSegment) => {
           // ignore initial & trailing slashes
-          if (pathSegment === '' || pathSegment === '/') {
-            return;
-          }
+          if (pathSegment === '' || pathSegment === '/') return;
+
           // rebuild link urls segment by segment
           url += `/${pathSegment}`;
 
@@ -56,7 +55,8 @@ const generateTitles = (crumb: string) => {
 
 const formatTitle = (title: string) => {
   return title
-    .split('-')
+    .split('-') // from kebab-case to Title Case
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+    .join(' ')
+    .split('#')[0]; // remove hash-links from title
 };

--- a/functions/titleCaseToKebabCase.ts
+++ b/functions/titleCaseToKebabCase.ts
@@ -1,0 +1,17 @@
+/**
+ * Converts a Title Case string to kebab-case
+ *
+ * @param {string} input - the title-case string to convert
+ * @returns {string} - kebav-case version
+ *
+ * @example
+ * titleCaseToKebabCase("Hello, World!") -> rtns: "hello-world"
+ */
+
+export function titleCaseToKebabCase(input: string) {
+  // regex to match punctuation for removal
+  const punctionation = /[\.,?!']/g;
+
+  // remove punctuation, replace hyphens with spaces
+  return input.toLowerCase().replace(punctionation, '').split(' ').join('-');
+}

--- a/pages/classes/[className]/index.vue
+++ b/pages/classes/[className]/index.vue
@@ -60,7 +60,11 @@
     <!-- Class Abilities -->
     <section>
       <ul v-if="featuresInOrder.length > 0">
-        <li v-for="feature in featuresInOrder" :key="feature.key">
+        <li
+          v-for="feature in featuresInOrder"
+          :id="titleCaseToKebabCase(feature.name)"
+          :key="feature.key"
+        >
           <h3>{{ feature.name }}</h3>
           <md-viewer :text="feature.desc" header-level="3" />
         </li>
@@ -72,6 +76,7 @@
 </template>
 
 <script setup>
+import { titleCaseToKebabCase } from '~/functions/titleCaseToKebabCase';
 const { data: classData } = useFindOne(
   API_ENDPOINTS.classes,
   useRoute().params.className,


### PR DESCRIPTION
## Description
This PR updates the ClassTable component so that each feature name is a link to the full description of that feature futher down the page. This was achieved by using hash-links to jump to elements with specified IDs.

Additional work was undertaken in other files to fix bugs that occured. The `useBreadcrumb` composable needed to be updated so that hash-links were filtered out from the breadcrumbs correctly.

The `titleCaseToKebabCase()` utility function was created to avoid code duplication between `/pages/classes/[className]/index.vue` and `/components/ClassTable.vue`. 


## Type of Change
- Bug fix
- *__New feature__*
- Refactor
- Documentation update
- Other (please specify):

## Related Issue

Closes #648 

## How has this been tested?

The changes have been tested manually on a local test server (see screenshots) - data was pulled from a Django test server running the current `staging` branch of the Open5e API.

The following commands execute without error:
- `npm run test`
- `npm run lint`
- `npm run build`
- `npm run generate`

## Screenshots

![ScreenRecording2025-03-30at15 31 07-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f19ccebe-5baa-499d-9239-be4a71b6528a)


## Notes

From a UX perspective there are a couple of problems with this feature that should be tackled in future issues:

1) When a hash-link is clicked the scroll position immediately jumps to the full description of the feature. A smooth scroll would be prefered.

2) Navigating to a hash-link and pushing back should take users back to the top of the screen.

Both of these will likely require a closer look at the Router, which has given us our fair share of headaches historically (issue #460 hasn't been solved yet, and it has been over a year!)