### PR TITLE
Fixed misaligned `SortableTableHeader`

### DIFF
--- a/components/SortableTableHeader.vue
+++ b/components/SortableTableHeader.vue
@@ -25,7 +25,7 @@
   <th
     :aria-sort="isSortDescending"
     class="align-baseline"
-    :class="{ 'hidden sm:block': isLeastPriority }"
+    :class="{ 'hidden sm:table-cell': isLeastPriority }"
   >
     <button v-if="sortBy" @click="onClick">
       <span>


### PR DESCRIPTION
## Description

This PR fixes a small visual bug observed in the `<SortableTableHeader>` component. The fix required a single TailwindCSS class to be updated so that all headers have a `display` value of `table-cell` rather than `block`.

## Type of Change
Bugfix (UI)

## Related Issue
Closes #656

## How has this been tested?

The changes have been A-B tested against staging to confirm that they are working (see screenshots).

Tests have been run (`npm run test`) and all pass.

## Screenshots

Before, `staging` branch (n.b. `Size` table header doesn't line up with the others)

<img width="915" alt="Screenshot 2025-03-31 at 17 34 31" src="https://github.com/user-attachments/assets/45bcc75c-b4ed-484f-b695-eb5e81e1eb27" />
 
After, feature branch (n.b. `Size` table header lines up with the other headers)

<img width="915" alt="Screenshot 2025-03-31 at 17 33 49" src="https://github.com/user-attachments/assets/26a82a1d-6879-4f1f-8d97-330c24881ed0" />
