### PR TITLE
Added initiative bonus to single-view Monster page

### DIFF
--- a/composables/useDicerRoller.ts
+++ b/composables/useDicerRoller.ts
@@ -1,7 +1,9 @@
 import { useNotifications } from './useNotifications';
 const { addNotif } = useNotifications();
 
-export function useDiceRoller(signature: string) {
+export function useDiceRoller(input: string | number) {
+  const signature = typeof input === 'string' ? input : input.toString();
+
   // extract numerical data from dice signature
   const parsed = parseDice(signature);
   // make sure parseDice rtn'd data before deconstructing arr.

--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -43,10 +43,10 @@
       <source-tag :title="monster.document.name" :text="monster.document.key" />
     </p>
 
-    <ul>
-      <!-- Size / Type / Alignment / Source Tag -->
-      <li>
-        <span class="font-bold after:content-['_']">Armor Class</span>
+    <dl class="grid grid-cols-[10rem_1fr]">
+      <!-- ARMOR CLASS -->
+      <dt class="font-bold after:content-['_']">Armor Class</dt>
+      <dd>
         <span>{{ monster.armor_class }}</span>
         <span
           v-if="monster.armor_desc"
@@ -54,9 +54,22 @@
         >
           {{ monster.armor_desc }}
         </span>
-      </li>
-      <li>
-        <span class="font-bold after:content-['_']">Hit Points</span>
+      </dd>
+
+      <!-- INITIATIVE BONUS -->
+      <dt class="font-bold after:content-['_']">Initiative Bonus</dt>
+      <dd
+        class="w-min cursor-pointer font-bold text-blood hover:text-black dark:hover:text-fog"
+        @click="useDiceRoller(monster.initiative_bonus)"
+      >
+        {{
+          (monster.initiative_bonus > 0 ? '+' : '') + monster.initiative_bonus
+        }}
+      </dd>
+
+      <!-- HIT POINTS -->
+      <dt class="font-bold after:content-['_']">Hit Points</dt>
+      <dd>
         <span class="after:content-['_']">{{ monster.hit_points }}</span>
         <span
           v-if="monster.hit_dice"
@@ -65,25 +78,20 @@
         >
           {{ `(${monster.hit_dice})` }}
         </span>
-      </li>
+      </dd>
 
-      <!-- SPEED -->
-      <li>
-        <span class="font-bold after:content-['_']">Speed</span>
+      <!-- SPEEDS -->
+      <dt class="font-bold after:content-['_']">Speed</dt>
+      <dd>
         <span
-          v-for="(speed, key) in speeds"
-          :key="key"
+          v-for="speed in speeds"
+          :key="speed"
           class="after:content-[',_'] last:after:content-[]"
         >
-          <span v-if="key !== 'walk'" class="after:content-['_']">
-            {{ key }}
-          </span>
-          <span class="after:content-['_ft.']">
-            {{ speed }}
-          </span>
+          {{ speed }}
         </span>
-      </li>
-    </ul>
+      </dd>
+    </dl>
 
     <hr />
 
@@ -302,11 +310,14 @@ const snakeToTitleCase = (input) =>
     .map((word) => word[0].toUpperCase() + word.substring(1))
     .join(' ');
 
-// filter "unit" prop from "speeds"
+// Format monster speeds for template
 const speeds = computed(() => {
   if (!monster?.value?.speed) return {};
-  const { unit, ...rest } = monster.value.speed;
-  return rest;
+  const { unit, ...speeds } = monster.value.speed;
+  return Object.entries(speeds).map(
+    ([speed, distance]) =>
+      (speed === 'walk' ? '' : speed + ' ') + `${distance} ft.`
+  );
 });
 
 // assemble senses from multiple fields


### PR DESCRIPTION
## Description

This PR adds a monster's initiative bonus to the stat blocks presented on `/monster/[id]`. At the request of users on the Open5e Discord, this has been made a rollable link (ie. clicking on it rolls initiatve) via the `useDiceRoller()` composable.

Additional work was undertaken to update the `useDiceRoller()` composable so that it converts numbers passed to it into strings before parsing the dice formula. Also, the template code that handles the information immediately adjacent to the Initiative Bonus was lightly refactored for improved code readibility and HTML semantics.


## Type

***Feature*** (enchancement) - presenting additional API data on the front-end

## Related Issue

Closes #649  

## How was this tested?

This PR was tested visually by spinning up the website on a test server (pointed at the current `staging` branch of the API, also running on a test server) and visiting various monster pages. See screenshots below.

The following commands were run locally to make sure everything was working as it should:
- `npm run test`
- `npm run lint`
- `npm run build`
- `npm run generate`

## Screenshots

Initiave bonus on statblock (light mode)

<img width="822" alt="Screenshot 2025-04-01 at 10 22 38" src="https://github.com/user-attachments/assets/5ff653cb-58e5-4ed4-b874-3f5d24a5db9f" />


Initiative bonus on statblock (dark mode)

<img width="825" alt="Screenshot 2025-04-01 at 10 22 48" src="https://github.com/user-attachments/assets/84c2e50a-98d0-45cf-af00-3cfddb3f9b68" />

Clicking Initiative Bonus invokes the dice roller

<img width="825" alt="Screenshot 2025-04-01 at 10 23 05" src="https://github.com/user-attachments/assets/34faaf81-35f1-4f08-a47d-f3c1b98fa86a" />
