### PR TITLE
Hotfix: added missing data to `monster/[id]` page

### DIFF
--- a/pages/monsters/[id].vue
+++ b/pages/monsters/[id].vue
@@ -99,6 +99,48 @@
 
     <hr />
 
+    <!-- FEATURES UNDER ABILITIES -->
+    <section>
+      <dl>
+        <!-- SAVING THROWS -->
+        <div v-if="savingThrows.length > 0">
+          <dt class="inline font-bold">{{ 'Saving Throws' + ' ' }}</dt>
+          <dl class="inline">
+            <span
+              v-for="save in savingThrows"
+              :key="save.label"
+              class="cursor-pointer font-bold text-blood after:content-[',_'] last:after:content-[''] hover:text-black dark:hover:text-white"
+              @click="useDiceRoller(save.value.toString())"
+            >
+              {{ save.label + ' ' + (save.value >= 0 ? '+' : '') + save.value }}
+            </span>
+          </dl>
+        </div>
+
+        <!-- SKILLS -->
+        <div v-if="Object.keys(monster.skills).length > 0">
+          <dt class="inline font-bold">{{ 'Skills' + ' ' }}</dt>
+          <dl class="inline capitalize">
+            <span
+              v-for="(mod, skill) in monster.skills"
+              :key="skill"
+              class="cursor-pointer font-bold text-blood after:content-[',_'] last:after:content-[''] hover:text-black dark:hover:text-white"
+              @click="useDiceRoller(mod.toString())"
+            >
+              {{ skill + ' ' + (mod >= 0 ? '+' : '') + mod }}
+            </span>
+          </dl>
+        </div>
+
+        <!-- LANGUAGES, SENSES, RESISTANCES, ETC. -->
+        <div v-for="field in monsterFeatures" :key="field.title">
+          <dt class="inline font-bold">{{ field.title + ' ' }}</dt>
+          <dd class="inline">{{ field.data }}</dd>
+        </div>
+      </dl>
+      <hr />
+    </section>
+
     <!-- Monster Special Abilities -->
     <section v-if="monster.special_abilities">
       <p
@@ -232,6 +274,54 @@
 <script setup>
 const route = useRoute();
 const { data: monster } = useMonster(route.params.id);
+
+const savingThrows = computed(() => {
+  if (!monster) {
+    return [];
+  }
+  const saves = [
+    { label: 'Str', value: monster.value.strength_save },
+    { label: 'Dex', value: monster.value.dexterity_save },
+    { label: 'Con', value: monster.value.constitution_save },
+    { label: 'Int', value: monster.value.intelligence_save },
+    { label: 'Wis', value: monster.value.wisdom_save },
+    { label: 'Cha', value: monster.value.charisma_save },
+  ].filter((save) => save.value);
+  return saves;
+});
+
+const monsterFeatures = computed(() => {
+  if (!monster) {
+    return [];
+  }
+  const features = [
+    {
+      title: 'Damage Vulnerabilities',
+      data: monster.value.damage_vulnerabilities,
+    },
+    {
+      title: 'Damage Resistances',
+      data: monster.value.damage_resistances,
+    },
+    {
+      title: 'Damage Immunities',
+      data: monster.value.damage_immunities,
+    },
+    {
+      title: 'Condition Immunities',
+      data: monster.value.condition_immunities,
+    },
+    {
+      title: 'Senses',
+      data: monster.value.senses,
+    },
+    {
+      title: 'Languages',
+      data: monster.value.languages,
+    },
+  ].filter((feature) => feature.data);
+  return features;
+});
 
 const mode = ref(route.query.mode || 'normal');
 function toggleMode() {

--- a/tests/unit/pages/monster.test.tsx
+++ b/tests/unit/pages/monster.test.tsx
@@ -5,6 +5,7 @@ import {
   mountSuspended,
 } from '@nuxt/test-utils/runtime';
 import MonsterPage from '~/pages/monsters/[id].vue';
+import { ref } from 'vue';
 
 const page = await mountSuspended(MonsterPage);
 
@@ -18,15 +19,15 @@ test('/monsters/[id] page can mount', async () => {
 test('/monsters/[id] page renders title', async () => {
   const title = page.find('h1');
   expect(title.exists()).toBe(true);
-  expect(title.text()).toEqual(monster.name);
+  expect(title.text()).toEqual(monster.value.name);
 });
 
 test('/monsters/[id] page renders correct number of actions', async () => {
   const actions = page.find('#actions-list');
-  if (!monster.actions || monster.actions.length === 0) {
+  if (!monster.value.actions || monster.value.actions.length === 0) {
     expect(actions.exists()).toBe(false);
   } else {
-    expect(actions.findAll('li').length).toEqual(monster.actions.length);
+    expect(actions.findAll('li').length).toEqual(monster.value.actions.length);
   }
 });
 
@@ -45,7 +46,7 @@ mockNuxtImport('useRoute', () => {
 // mock API result from /monster/[id] endpoint
 mockNuxtImport('useMonster', () => {
   return () => ({
-    data: {
+    data: ref({
       slug: 'aboleth',
       desc: '',
       name: 'Aboleth',
@@ -151,6 +152,6 @@ mockNuxtImport('useMonster', () => {
       document__license_url: 'http://open5e.com/legal',
       document__url:
         'http://dnd.wizards.com/articles/features/systems-reference-document-srd',
-    },
+    }),
   });
 });


### PR DESCRIPTION
## Description

This PR fixes an issue flagged by 3d6inOrder on Discord (thank you!) where the block of infomation typically included on a monster's statblock underneath the ability scores was missing from the `/monsters/[id]` page on the live site.

This data was returned by the API, but wasn't being rendered on the front-end. I have expanded the markup on the `/pages/monsters/[id].vue` to include additional sections for rendering this data

This bug has been fixed on the `staging` branch, but as this branch also contains our work on the V2 switch-over (mostly complete, but not quite there yet), but as this is a bug effecting users on the live site and we want to fix it ASAP, I am opening this PR against the `main` branch. This was the option that made the most sense to me, let me know if you think there is a better method of handling this, ie. a `hotfixes` branch.